### PR TITLE
feat: economy commands (wallet, clock-in/out, inbox, pay/contest fine)

### DIFF
--- a/commands/clock-in.js
+++ b/commands/clock-in.js
@@ -1,22 +1,13 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, getLpcUser, findOption, getFocusedOption, civilianName } = require('../util/economy');
+const { formatMoney, getLpcUser, findOption, getFocusedOption, civilianName, listClockableDepartments } = require('../util/economy');
 
 async function listUserCivilians(client, userId, communityId) {
   const res = await apiRequest(
     client,
     'GET',
     `/api/v2/civilians/user/${userId}?active_community_id=${encodeURIComponent(communityId)}&limit=50`
-  );
-  return (res && res.data) || [];
-}
-
-async function listUserDepartments(client, communityId, userId) {
-  const res = await apiRequest(
-    client,
-    'GET',
-    `/api/v2/community/${communityId}/my-departments?userId=${encodeURIComponent(userId)}&limit=50`
   );
   return (res && res.data) || [];
 }
@@ -58,7 +49,7 @@ module.exports = {
 
       try {
         if (focused.name === 'department') {
-          const depts = await listUserDepartments(client, communityId, userId);
+          const depts = await listClockableDepartments(client, communityId, userId);
           const choices = depts
             .map((d) => ({ name: d.name || 'Unnamed Department', value: String(d._id) }))
             .filter((c) => !q || c.name.toLowerCase().includes(q))

--- a/commands/clock-in.js
+++ b/commands/clock-in.js
@@ -38,9 +38,9 @@ module.exports = {
     },
     {
       name: "civilian",
-      description: "Civilian to clock in as (optional)",
+      description: "Civilian to clock in as",
       type: CommandOptions.String,
-      required: false,
+      required: true,
       autocomplete: true,
     },
   ],
@@ -100,6 +100,8 @@ module.exports = {
 
       if (!departmentId)
         return interaction.send({ content: `Please pick a department to clock into.`, flags: (1 << 6) });
+      if (!civilianId)
+        return interaction.send({ content: `Please pick a civilian to clock in as.`, flags: (1 << 6) });
 
       await interaction.defer();
 

--- a/commands/clock-in.js
+++ b/commands/clock-in.js
@@ -1,25 +1,19 @@
 const { EmbedBuilder } = require('discord.js');
-const ObjectId = require('mongodb').ObjectId;
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, getLpcUser, findOption, getFocusedOption, civilianName, listClockableDepartments } = require('../util/economy');
+const {
+  formatMoney,
+  getLpcUser,
+  findOption,
+  getFocusedOption,
+  civilianAutocomplete,
+  listClockableDepartments,
+  resolveCivilianId,
+  lookupCivilianName,
+  isCommunityEconomyEnabled,
+} = require('../util/economy');
 
-async function lookupCivilianName(client, civilianId) {
-  if (!civilianId) return null;
-  let oid;
-  try { oid = new ObjectId(civilianId); } catch (_) { return null; }
-  const doc = await client.dbo.collection('civilians').findOne({ _id: oid });
-  return doc ? civilianName(doc) : null;
-}
-
-async function listUserCivilians(client, userId, communityId) {
-  const res = await apiRequest(
-    client,
-    'GET',
-    `/api/v2/civilians/user/${userId}?active_community_id=${encodeURIComponent(communityId)}&limit=50`
-  );
-  return (res && res.data) || [];
-}
+const NO_DEPT_HELP = `You don't have any departments you can clock into. This usually means you aren't an approved member of any economy-enabled department, or your community's economy is turned off. Ask your community admin to confirm your membership and that the department has economy enabled.`;
 
 module.exports = {
   name: "clock-in",
@@ -38,9 +32,9 @@ module.exports = {
     },
     {
       name: "civilian",
-      description: "Civilian to clock in as",
+      description: "Override your active civilian for this shift",
       type: CommandOptions.String,
-      required: true,
+      required: false,
       autocomplete: true,
     },
   ],
@@ -54,10 +48,10 @@ module.exports = {
       const communityId = user.user.lastAccessedCommunity.communityID;
       const focused = getFocusedOption(interaction.data.options);
       if (!focused) return interaction.respond([]);
-      const q = (focused.value || '').toLowerCase();
 
       try {
         if (focused.name === 'department') {
+          const q = (focused.value || '').toLowerCase();
           const depts = await listClockableDepartments(client, communityId, userId);
           const choices = depts
             .map((d) => ({ name: d.name || 'Unnamed Department', value: String(d._id) }))
@@ -66,11 +60,7 @@ module.exports = {
           return interaction.respond(choices);
         }
         if (focused.name === 'civilian') {
-          const civs = await listUserCivilians(client, userId, communityId);
-          const choices = civs
-            .map((c) => ({ name: civilianName(c), value: c._id.toString() }))
-            .filter((c) => !q || c.name.toLowerCase().includes(q))
-            .slice(0, 25);
+          const choices = await civilianAutocomplete(client, userId, communityId, focused.value);
           return interaction.respond(choices);
         }
         return interaction.respond([]);
@@ -96,28 +86,40 @@ module.exports = {
       const userId = user._id.toString();
       const communityId = user.user.lastAccessedCommunity.communityID;
       const departmentId = (findOption(args, 'department') || {}).value;
-      const civilianId = (findOption(args, 'civilian') || {}).value || '';
+      const explicitId = (findOption(args, 'civilian') || {}).value || '';
 
       if (!departmentId)
         return interaction.send({ content: `Please pick a department to clock into.`, flags: (1 << 6) });
-      if (!civilianId)
-        return interaction.send({ content: `Please pick a civilian to clock in as.`, flags: (1 << 6) });
 
       await interaction.defer();
 
-      try {
-        const body = { communityId, departmentId };
-        if (civilianId) body.civilianId = civilianId;
+      if (!(await isCommunityEconomyEnabled(client, communityId))) {
+        return interaction.editOriginal({ content: `Economy is not enabled in your community. Ask your community admin to enable this.` });
+      }
 
+      const eligible = await listClockableDepartments(client, communityId, userId);
+      if (eligible.length === 0) {
+        return interaction.editOriginal({ content: NO_DEPT_HELP });
+      }
+      if (!eligible.some((d) => String(d._id) === departmentId)) {
+        return interaction.editOriginal({ content: NO_DEPT_HELP });
+      }
+
+      const civilianId = await resolveCivilianId(client, userId, communityId, explicitId);
+      if (!civilianId) {
+        return interaction.editOriginal({ content: `No civilian selected. Run \`/set-active-civilian\` or pass \`civilian:\` on this command.` });
+      }
+
+      try {
         const session = await apiRequest(
           client,
           'POST',
           `/api/v2/economy/clock-in?userId=${encodeURIComponent(userId)}`,
-          body,
+          { communityId, departmentId, civilianId },
         );
 
         const rate = session.payRateSnapshot ? `${formatMoney(session.payRateSnapshot)}/hr` : 'unknown';
-        const civName = (await lookupCivilianName(client, session.civilianId)) || 'User-level shift';
+        const civName = (await lookupCivilianName(client, session.civilianId)) || 'Unknown';
         const embed = new EmbedBuilder()
           .setColor('#38bdf8')
           .setAuthor({ name: 'Clocked In', iconURL: client.config.IconURL })
@@ -137,7 +139,7 @@ module.exports = {
         if (msg.includes('(409)'))
           return interaction.editOriginal({ content: `You already have an active shift. Use \`/clock-out\` first.` });
         if (msg.includes('(403)'))
-          return interaction.editOriginal({ content: `You don't have access to that department, or its economy is disabled.` });
+          return interaction.editOriginal({ content: NO_DEPT_HELP });
         if (msg.includes('(404)'))
           return interaction.editOriginal({ content: `Department not found.` });
         return interaction.editOriginal({ content: `Failed to clock in. Please try again.` });

--- a/commands/clock-in.js
+++ b/commands/clock-in.js
@@ -1,0 +1,148 @@
+const { EmbedBuilder } = require('discord.js');
+const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
+const { apiRequest } = require('../util/api');
+const { formatMoney, getLpcUser, findOption, getFocusedOption } = require('../util/economy');
+
+function civilianName(civ) {
+  const d = (civ && civ.civilian) || {};
+  return `${d.firstName || ''} ${d.lastName || ''}`.trim() || 'Unnamed';
+}
+
+async function listUserCivilians(client, userId, communityId) {
+  const res = await apiRequest(
+    client,
+    'GET',
+    `/api/v2/civilians/user/${userId}?active_community_id=${encodeURIComponent(communityId)}&limit=50`
+  );
+  return (res && res.data) || [];
+}
+
+async function listUserDepartments(client, communityId, userId) {
+  const res = await apiRequest(
+    client,
+    'GET',
+    `/api/v2/community/${communityId}/my-departments?userId=${encodeURIComponent(userId)}&limit=50`
+  );
+  return (res && res.data) || [];
+}
+
+module.exports = {
+  name: "clock-in",
+  description: "Start an on-duty shift to earn pay",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [
+    {
+      name: "department",
+      description: "Department to clock into",
+      type: CommandOptions.String,
+      required: true,
+      autocomplete: true,
+    },
+    {
+      name: "civilian",
+      description: "Civilian to clock in as (optional)",
+      type: CommandOptions.String,
+      required: false,
+      autocomplete: true,
+    },
+  ],
+  Autocomplete: {
+    run: async (client, interaction) => {
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
+        return interaction.respond([]);
+      }
+      const userId = user._id.toString();
+      const communityId = user.user.lastAccessedCommunity.communityID;
+      const focused = getFocusedOption(interaction.data.options);
+      if (!focused) return interaction.respond([]);
+      const q = (focused.value || '').toLowerCase();
+
+      try {
+        if (focused.name === 'department') {
+          const depts = await listUserDepartments(client, communityId, userId);
+          const choices = depts
+            .map((d) => ({ name: d.name || 'Unnamed Department', value: String(d._id) }))
+            .filter((c) => !q || c.name.toLowerCase().includes(q))
+            .slice(0, 25);
+          return interaction.respond(choices);
+        }
+        if (focused.name === 'civilian') {
+          const civs = await listUserCivilians(client, userId, communityId);
+          const choices = civs
+            .map((c) => ({ name: civilianName(c), value: c._id.toString() }))
+            .filter((c) => !q || c.name.toLowerCase().includes(q))
+            .slice(0, 25);
+          return interaction.respond(choices);
+        }
+        return interaction.respond([]);
+      } catch (err) {
+        client.error(`/clock-in autocomplete: ${err.message}`);
+        return interaction.respond([]);
+      }
+    },
+  },
+  SlashCommand: {
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
+      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });
+      if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID)
+        return interaction.send({ content: `You must join a community to use this command.`, flags: (1 << 6) });
+
+      const userId = user._id.toString();
+      const communityId = user.user.lastAccessedCommunity.communityID;
+      const departmentId = (findOption(args, 'department') || {}).value;
+      const civilianId = (findOption(args, 'civilian') || {}).value || '';
+
+      if (!departmentId)
+        return interaction.send({ content: `Please pick a department to clock into.`, flags: (1 << 6) });
+
+      await interaction.defer();
+
+      try {
+        const body = { communityId, departmentId };
+        if (civilianId) body.civilianId = civilianId;
+
+        const session = await apiRequest(
+          client,
+          'POST',
+          `/api/v2/economy/clock-in?userId=${encodeURIComponent(userId)}`,
+          body,
+        );
+
+        const rate = session.payRateSnapshot ? `${formatMoney(session.payRateSnapshot)}/hr` : 'unknown';
+        const embed = new EmbedBuilder()
+          .setColor('#38bdf8')
+          .setAuthor({ name: 'Clocked In', iconURL: client.config.IconURL })
+          .setTitle(session.departmentName || 'On Duty')
+          .addFields(
+            { name: '**Pay Rate**', value: `\`${rate}\``, inline: true },
+            { name: '**Mode**', value: `\`${session.payoutMode || 'on_clockout'}\``, inline: true },
+            { name: '**Max Session**', value: `\`${session.maxSessionMinutes || 120}m\``, inline: true },
+          );
+
+        return interaction.editOriginal({ embeds: [embed] });
+      } catch (err) {
+        const msg = err && err.message ? err.message : String(err);
+        client.error(`/clock-in error: ${msg}`);
+        // Surface the common "already on duty" 409 case clearly.
+        if (msg.includes('(409)'))
+          return interaction.editOriginal({ content: `You already have an active shift. Use \`/clock-out\` first.` });
+        if (msg.includes('(403)'))
+          return interaction.editOriginal({ content: `You don't have access to that department, or its economy is disabled.` });
+        if (msg.includes('(404)'))
+          return interaction.editOriginal({ content: `Department not found.` });
+        return interaction.editOriginal({ content: `Failed to clock in. Please try again.` });
+      }
+    },
+  },
+};

--- a/commands/clock-in.js
+++ b/commands/clock-in.js
@@ -1,7 +1,16 @@
 const { EmbedBuilder } = require('discord.js');
+const ObjectId = require('mongodb').ObjectId;
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
 const { formatMoney, getLpcUser, findOption, getFocusedOption, civilianName, listClockableDepartments } = require('../util/economy');
+
+async function lookupCivilianName(client, civilianId) {
+  if (!civilianId) return null;
+  let oid;
+  try { oid = new ObjectId(civilianId); } catch (_) { return null; }
+  const doc = await client.dbo.collection('civilians').findOne({ _id: oid });
+  return doc ? civilianName(doc) : null;
+}
 
 async function listUserCivilians(client, userId, communityId) {
   const res = await apiRequest(
@@ -106,11 +115,13 @@ module.exports = {
         );
 
         const rate = session.payRateSnapshot ? `${formatMoney(session.payRateSnapshot)}/hr` : 'unknown';
+        const civName = (await lookupCivilianName(client, session.civilianId)) || 'User-level shift';
         const embed = new EmbedBuilder()
           .setColor('#38bdf8')
           .setAuthor({ name: 'Clocked In', iconURL: client.config.IconURL })
           .setTitle(session.departmentName || 'On Duty')
           .addFields(
+            { name: '**Civilian**', value: `\`${civName}\``, inline: true },
             { name: '**Pay Rate**', value: `\`${rate}\``, inline: true },
             { name: '**Mode**', value: `\`${session.payoutMode || 'on_clockout'}\``, inline: true },
             { name: '**Max Session**', value: `\`${session.maxSessionMinutes || 120}m\``, inline: true },

--- a/commands/clock-in.js
+++ b/commands/clock-in.js
@@ -1,12 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, getLpcUser, findOption, getFocusedOption } = require('../util/economy');
-
-function civilianName(civ) {
-  const d = (civ && civ.civilian) || {};
-  return `${d.firstName || ''} ${d.lastName || ''}`.trim() || 'Unnamed';
-}
+const { formatMoney, getLpcUser, findOption, getFocusedOption, civilianName } = require('../util/economy');
 
 async function listUserCivilians(client, userId, communityId) {
   const res = await apiRequest(

--- a/commands/clock-out.js
+++ b/commands/clock-out.js
@@ -1,0 +1,64 @@
+const { EmbedBuilder } = require('discord.js');
+const { apiRequest } = require('../util/api');
+const { formatMoney, formatDuration, getLpcUser } = require('../util/economy');
+
+module.exports = {
+  name: "clock-out",
+  description: "End your active shift",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [],
+  SlashCommand: {
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
+      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });
+
+      const userId = user._id.toString();
+      await interaction.defer();
+
+      try {
+        const active = await apiRequest(
+          client,
+          'GET',
+          `/api/v2/economy/session/active?userId=${encodeURIComponent(userId)}`,
+        );
+        if (!active || !active._id) {
+          return interaction.editOriginal({ content: `You don't have an active user-level shift. If you clocked in as a civilian, end it from the website or app.` });
+        }
+
+        const result = await apiRequest(
+          client,
+          'POST',
+          `/api/v2/economy/clock-out?userId=${encodeURIComponent(userId)}`,
+          { sessionId: String(active._id) },
+        );
+
+        const sess = (result && result.session) || result;
+        const credited = (result && typeof result.creditedAmount === 'number') ? result.creditedAmount : 0;
+        const elapsed = sess && sess.startedAt ? Date.now() - new Date(sess.startedAt).getTime() : 0;
+
+        const embed = new EmbedBuilder()
+          .setColor('#38bdf8')
+          .setAuthor({ name: 'Clocked Out', iconURL: client.config.IconURL })
+          .setTitle(sess.departmentName || 'Off Duty')
+          .addFields(
+            { name: '**Earned**', value: `\`${formatMoney(credited)}\``, inline: true },
+            { name: '**Shift Length**', value: `\`${formatDuration(elapsed)}\``, inline: true },
+          );
+
+        return interaction.editOriginal({ embeds: [embed] });
+      } catch (err) {
+        client.error(`/clock-out error: ${err.message}`);
+        return interaction.editOriginal({ content: `Failed to clock out. Please try again.` });
+      }
+    },
+  },
+};

--- a/commands/clock-out.js
+++ b/commands/clock-out.js
@@ -1,20 +1,11 @@
 const { EmbedBuilder } = require('discord.js');
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDuration, getLpcUser, civilianName } = require('../util/economy');
-const ObjectId = require('mongodb').ObjectId;
+const { formatMoney, formatDuration, getLpcUser, lookupCivilianName } = require('../util/economy');
 
 async function findActiveSessionForUser(client, userId) {
   return client.dbo
     .collection('clock_sessions')
     .findOne({ status: 'active', userId });
-}
-
-async function lookupCivilianName(client, civilianId) {
-  if (!civilianId) return null;
-  let oid;
-  try { oid = new ObjectId(civilianId); } catch (_) { return null; }
-  const doc = await client.dbo.collection('civilians').findOne({ _id: oid });
-  return doc ? civilianName(doc) : null;
 }
 
 module.exports = {

--- a/commands/clock-out.js
+++ b/commands/clock-out.js
@@ -1,6 +1,21 @@
 const { EmbedBuilder } = require('discord.js');
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDuration, getLpcUser } = require('../util/economy');
+const { formatMoney, formatDuration, getLpcUser, civilianName } = require('../util/economy');
+const ObjectId = require('mongodb').ObjectId;
+
+async function findActiveSessionForUser(client, userId) {
+  return client.dbo
+    .collection('clock_sessions')
+    .findOne({ status: 'active', userId });
+}
+
+async function lookupCivilianName(client, civilianId) {
+  if (!civilianId) return null;
+  let oid;
+  try { oid = new ObjectId(civilianId); } catch (_) { return null; }
+  const doc = await client.dbo.collection('civilians').findOne({ _id: oid });
+  return doc ? civilianName(doc) : null;
+}
 
 module.exports = {
   name: "clock-out",
@@ -25,13 +40,9 @@ module.exports = {
       await interaction.defer();
 
       try {
-        const active = await apiRequest(
-          client,
-          'GET',
-          `/api/v2/economy/session/active?userId=${encodeURIComponent(userId)}`,
-        );
-        if (!active || !active._id) {
-          return interaction.editOriginal({ content: `You don't have an active user-level shift. If you clocked in as a civilian, end it from the website or app.` });
+        const active = await findActiveSessionForUser(client, userId);
+        if (!active) {
+          return interaction.editOriginal({ content: `You don't have an active shift to clock out of.` });
         }
 
         const result = await apiRequest(
@@ -44,12 +55,14 @@ module.exports = {
         const sess = (result && result.session) || result;
         const credited = (result && typeof result.creditedAmount === 'number') ? result.creditedAmount : 0;
         const elapsed = sess && sess.startedAt ? Date.now() - new Date(sess.startedAt).getTime() : 0;
+        const civName = (await lookupCivilianName(client, sess.civilianId)) || 'User-level shift';
 
         const embed = new EmbedBuilder()
           .setColor('#38bdf8')
           .setAuthor({ name: 'Clocked Out', iconURL: client.config.IconURL })
           .setTitle(sess.departmentName || 'Off Duty')
           .addFields(
+            { name: '**Civilian**', value: `\`${civName}\``, inline: true },
             { name: '**Earned**', value: `\`${formatMoney(credited)}\``, inline: true },
             { name: '**Shift Length**', value: `\`${formatDuration(elapsed)}\``, inline: true },
           );

--- a/commands/contest-fine.js
+++ b/commands/contest-fine.js
@@ -119,8 +119,17 @@ module.exports = {
             { name: '**Civilian**', value: `\`${civName}\``, inline: true },
             { name: '**Amount**', value: `\`${formatMoney(item.amount)}\``, inline: true },
             { name: '**New Due Date**', value: `\`${formatDueDate(item.dueAt)}\``, inline: true },
-            { name: '**Reason**', value: `\`${reason.slice(0, 1000)}\`` },
           );
+
+        const chargeLines = (item.charges || [])
+          .filter((c) => c && c.label && c.status !== 'dismissed')
+          .map((c) => `• ${c.label} — ${formatMoney(c.amount)}`);
+        if (chargeLines.length > 0) {
+          embed.addFields({ name: '**Charges**', value: chargeLines.join('\n').slice(0, 1024) });
+        } else if (item.body) {
+          embed.addFields({ name: '**Details**', value: String(item.body).slice(0, 1024) });
+        }
+        embed.addFields({ name: '**Reason**', value: `\`${reason.slice(0, 1000)}\`` });
 
         return interaction.editOriginal({ embeds: [embed] });
       } catch (err) {

--- a/commands/contest-fine.js
+++ b/commands/contest-fine.js
@@ -1,0 +1,95 @@
+const { EmbedBuilder } = require('discord.js');
+const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
+const { apiRequest } = require('../util/api');
+const { formatMoney, formatDueDate, getLpcUser, findOption, getFocusedOption, fetchInboxChoices } = require('../util/economy');
+
+module.exports = {
+  name: "contest-fine",
+  description: "Contest a pending fine; extends its due date until a judge rules",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [
+    {
+      name: "fine",
+      description: "The fine to contest",
+      type: CommandOptions.String,
+      required: true,
+      autocomplete: true,
+    },
+    {
+      name: "reason",
+      description: "Why you're contesting this fine",
+      type: CommandOptions.String,
+      required: true,
+    },
+  ],
+  Autocomplete: {
+    run: async (client, interaction) => {
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
+        return interaction.respond([]);
+      }
+      const focused = getFocusedOption(interaction.data.options);
+      if (!focused || focused.name !== 'fine') return interaction.respond([]);
+      const choices = await fetchInboxChoices(
+        client,
+        user._id.toString(),
+        user.user.lastAccessedCommunity.communityID,
+        focused.value,
+        ['pending', 'delinquent'],
+      );
+      return interaction.respond(choices);
+    },
+  },
+  SlashCommand: {
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
+      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });
+
+      const userId = user._id.toString();
+      const fineId = (findOption(args, 'fine') || {}).value;
+      const reason = ((findOption(args, 'reason') || {}).value || '').trim();
+      if (!fineId) return interaction.send({ content: `Please pick a fine to contest.`, flags: (1 << 6) });
+      if (!reason) return interaction.send({ content: `Please provide a reason.`, flags: (1 << 6) });
+
+      await interaction.defer();
+
+      try {
+        const item = await apiRequest(
+          client,
+          'POST',
+          `/api/v2/economy/inbox/${encodeURIComponent(fineId)}/contest?userId=${encodeURIComponent(userId)}`,
+          { reason },
+        );
+
+        const embed = new EmbedBuilder()
+          .setColor('#38bdf8')
+          .setAuthor({ name: 'Fine Contested', iconURL: client.config.IconURL })
+          .setTitle(item.title || item.type || 'Contested')
+          .addFields(
+            { name: '**Amount**', value: `\`${formatMoney(item.amount)}\``, inline: true },
+            { name: '**New Due Date**', value: `\`${formatDueDate(item.dueAt)}\``, inline: true },
+            { name: '**Reason**', value: `\`${reason.slice(0, 1000)}\`` },
+          );
+
+        return interaction.editOriginal({ embeds: [embed] });
+      } catch (err) {
+        const msg = err && err.message ? err.message : String(err);
+        client.error(`/contest-fine error: ${msg}`);
+        if (msg.includes('(400)'))
+          return interaction.editOriginal({ content: `Only pending fines can be contested, and not ones already ruled on.` });
+        if (msg.includes('(404)'))
+          return interaction.editOriginal({ content: `Fine not found.` });
+        return interaction.editOriginal({ content: `Failed to contest fine. Please try again.` });
+      }
+    },
+  },
+};

--- a/commands/contest-fine.js
+++ b/commands/contest-fine.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDueDate, getLpcUser, findOption, getFocusedOption, fetchInboxChoices } = require('../util/economy');
+const { formatMoney, formatDueDate, getLpcUser, findOption, getFocusedOption, fetchInboxChoices, civilianAutocomplete } = require('../util/economy');
 
 module.exports = {
   name: "contest-fine",
@@ -11,6 +11,13 @@ module.exports = {
     member: [],
   },
   options: [
+    {
+      name: "civilian",
+      description: "Civilian who received the fine",
+      type: CommandOptions.String,
+      required: true,
+      autocomplete: true,
+    },
     {
       name: "fine",
       description: "The fine to contest",
@@ -31,16 +38,38 @@ module.exports = {
       if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
         return interaction.respond([]);
       }
+      const userId = user._id.toString();
+      const communityId = user.user.lastAccessedCommunity.communityID;
       const focused = getFocusedOption(interaction.data.options);
-      if (!focused || focused.name !== 'fine') return interaction.respond([]);
-      const choices = await fetchInboxChoices(
-        client,
-        user._id.toString(),
-        user.user.lastAccessedCommunity.communityID,
-        focused.value,
-        ['pending', 'delinquent'],
-      );
-      return interaction.respond(choices);
+      if (!focused) return interaction.respond([]);
+
+      if (focused.name === 'civilian') {
+        try {
+          const choices = await civilianAutocomplete(client, userId, communityId, focused.value);
+          return interaction.respond(choices);
+        } catch (err) {
+          client.error(`/contest-fine civilian autocomplete: ${err.message}`);
+          return interaction.respond([]);
+        }
+      }
+      if (focused.name === 'fine') {
+        const civilianId = (findOption(interaction.data.options, 'civilian') || {}).value;
+        if (!civilianId) return interaction.respond([]);
+        try {
+          const choices = await fetchInboxChoices(
+            client,
+            civilianId,
+            communityId,
+            focused.value,
+            ['pending', 'delinquent'],
+          );
+          return interaction.respond(choices);
+        } catch (err) {
+          client.error(`/contest-fine fine autocomplete: ${err.message}`);
+          return interaction.respond([]);
+        }
+      }
+      return interaction.respond([]);
     },
   },
   SlashCommand: {

--- a/commands/contest-fine.js
+++ b/commands/contest-fine.js
@@ -1,7 +1,17 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDueDate, getLpcUser, findOption, getFocusedOption, fetchInboxChoices, civilianAutocomplete } = require('../util/economy');
+const {
+  formatMoney,
+  formatDueDate,
+  getLpcUser,
+  findOption,
+  getFocusedOption,
+  fetchInboxChoices,
+  civilianAutocomplete,
+  resolveCivilianId,
+  lookupCivilianName,
+} = require('../util/economy');
 
 module.exports = {
   name: "contest-fine",
@@ -11,13 +21,6 @@ module.exports = {
     member: [],
   },
   options: [
-    {
-      name: "civilian",
-      description: "Civilian who received the fine",
-      type: CommandOptions.String,
-      required: true,
-      autocomplete: true,
-    },
     {
       name: "fine",
       description: "The fine to contest",
@@ -30,6 +33,13 @@ module.exports = {
       description: "Why you're contesting this fine",
       type: CommandOptions.String,
       required: true,
+    },
+    {
+      name: "civilian",
+      description: "Override your active civilian for this run",
+      type: CommandOptions.String,
+      required: false,
+      autocomplete: true,
     },
   ],
   Autocomplete: {
@@ -53,7 +63,8 @@ module.exports = {
         }
       }
       if (focused.name === 'fine') {
-        const civilianId = (findOption(interaction.data.options, 'civilian') || {}).value;
+        const explicitId = (findOption(interaction.data.options, 'civilian') || {}).value || '';
+        const civilianId = await resolveCivilianId(client, userId, communityId, explicitId);
         if (!civilianId) return interaction.respond([]);
         try {
           const choices = await fetchInboxChoices(
@@ -99,11 +110,13 @@ module.exports = {
           { reason },
         );
 
+        const civName = (await lookupCivilianName(client, item.civilianId)) || 'Unknown';
         const embed = new EmbedBuilder()
           .setColor('#38bdf8')
           .setAuthor({ name: 'Fine Contested', iconURL: client.config.IconURL })
           .setTitle(item.title || item.type || 'Contested')
           .addFields(
+            { name: '**Civilian**', value: `\`${civName}\``, inline: true },
             { name: '**Amount**', value: `\`${formatMoney(item.amount)}\``, inline: true },
             { name: '**New Due Date**', value: `\`${formatDueDate(item.dueAt)}\``, inline: true },
             { name: '**Reason**', value: `\`${reason.slice(0, 1000)}\`` },

--- a/commands/inbox.js
+++ b/commands/inbox.js
@@ -1,7 +1,16 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDueDate, getLpcUser, findOption, getFocusedOption, civilianAutocomplete } = require('../util/economy');
+const {
+  formatMoney,
+  formatDueDate,
+  getLpcUser,
+  findOption,
+  getFocusedOption,
+  civilianAutocomplete,
+  resolveCivilianId,
+  lookupCivilianName,
+} = require('../util/economy');
 
 const STATUS_LABEL = {
   pending: 'Pending',
@@ -21,9 +30,9 @@ module.exports = {
   options: [
     {
       name: "civilian",
-      description: "Civilian whose inbox to view",
+      description: "Override your active civilian for this run",
       type: CommandOptions.String,
-      required: true,
+      required: false,
       autocomplete: true,
     },
     {
@@ -75,23 +84,29 @@ module.exports = {
       if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID)
         return interaction.send({ content: `You must join a community to use this command.`, flags: (1 << 6) });
 
+      const userId = user._id.toString();
       const communityId = user.user.lastAccessedCommunity.communityID;
-      const civilianId = (findOption(args, 'civilian') || {}).value;
+      const explicitId = (findOption(args, 'civilian') || {}).value || '';
       const status = (findOption(args, 'status') || {}).value || 'pending';
 
-      if (!civilianId)
-        return interaction.send({ content: `Please pick a civilian.`, flags: (1 << 6) });
-
       await interaction.defer();
+
+      const civilianId = await resolveCivilianId(client, userId, communityId, explicitId);
+      if (!civilianId) {
+        return interaction.editOriginal({ content: `No civilian selected. Run \`/set-active-civilian\` or pass \`civilian:\` on this command.` });
+      }
 
       try {
         const path = `/api/v2/economy/inbox?civilianId=${encodeURIComponent(civilianId)}&communityId=${encodeURIComponent(communityId)}&limit=25` +
           (status === 'all' ? '' : `&status=${encodeURIComponent(status)}`);
-        const res = await apiRequest(client, 'GET', path);
+        const [res, civName] = await Promise.all([
+          apiRequest(client, 'GET', path),
+          lookupCivilianName(client, civilianId),
+        ]);
         const items = (res && res.data) || [];
 
         if (items.length === 0) {
-          return interaction.editOriginal({ content: `No items found for status \`${status}\`.` });
+          return interaction.editOriginal({ content: `No items found for \`${civName || 'this civilian'}\` with status \`${status}\`.` });
         }
 
         const lines = items.slice(0, 10).map((i) => {
@@ -106,6 +121,7 @@ module.exports = {
           .setColor('#38bdf8')
           .setAuthor({ name: 'Inbox', iconURL: client.config.IconURL })
           .setTitle(`${totalCount} ${status === 'all' ? 'item(s)' : status + ' item(s)'}`)
+          .addFields({ name: '**Civilian**', value: `\`${civName || 'Unknown'}\``, inline: true })
           .setDescription(lines.join('\n'))
           .setFooter({ text: `Use /pay-fine or /contest-fine with the full ID (or pick from autocomplete).` });
 

--- a/commands/inbox.js
+++ b/commands/inbox.js
@@ -1,0 +1,87 @@
+const { EmbedBuilder } = require('discord.js');
+const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
+const { apiRequest } = require('../util/api');
+const { formatMoney, formatDueDate, getLpcUser, findOption } = require('../util/economy');
+
+const STATUS_LABEL = {
+  pending: 'Pending',
+  contested: 'Contested',
+  delinquent: 'Delinquent',
+  paid: 'Paid',
+  dismissed: 'Dismissed',
+};
+
+module.exports = {
+  name: "inbox",
+  description: "List your fines, fees, and other financial items",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [
+    {
+      name: "status",
+      description: "Filter by status (default: pending)",
+      type: CommandOptions.String,
+      required: false,
+      choices: [
+        { name: "Pending", value: "pending" },
+        { name: "Contested", value: "contested" },
+        { name: "Delinquent", value: "delinquent" },
+        { name: "Paid", value: "paid" },
+        { name: "All", value: "all" },
+      ],
+    },
+  ],
+  SlashCommand: {
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
+      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });
+      if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID)
+        return interaction.send({ content: `You must join a community to use this command.`, flags: (1 << 6) });
+
+      const userId = user._id.toString();
+      const communityId = user.user.lastAccessedCommunity.communityID;
+      const status = (findOption(args, 'status') || {}).value || 'pending';
+
+      await interaction.defer();
+
+      try {
+        const path = `/api/v2/economy/inbox?userId=${encodeURIComponent(userId)}&communityId=${encodeURIComponent(communityId)}&limit=25` +
+          (status === 'all' ? '' : `&status=${encodeURIComponent(status)}`);
+        const res = await apiRequest(client, 'GET', path);
+        const items = (res && res.data) || [];
+
+        if (items.length === 0) {
+          return interaction.editOriginal({ content: `No items found for status \`${status}\`.` });
+        }
+
+        const lines = items.slice(0, 10).map((i) => {
+          const label = STATUS_LABEL[i.status] || i.status;
+          const idShort = String(i._id || '').slice(-6);
+          const title = i.title || i.type || 'Item';
+          return `• \`${idShort}\` — ${formatMoney(i.amount)} — ${title} (${label}, due ${formatDueDate(i.dueAt)})`;
+        });
+
+        const totalCount = (res && res.totalCount) || items.length;
+        const embed = new EmbedBuilder()
+          .setColor('#38bdf8')
+          .setAuthor({ name: 'Inbox', iconURL: client.config.IconURL })
+          .setTitle(`${totalCount} ${status === 'all' ? 'item(s)' : status + ' item(s)'}`)
+          .setDescription(lines.join('\n'))
+          .setFooter({ text: `Use /pay-fine or /contest-fine with the full ID (or pick from autocomplete).` });
+
+        return interaction.editOriginal({ embeds: [embed] });
+      } catch (err) {
+        client.error(`/inbox error: ${err.message}`);
+        return interaction.editOriginal({ content: `Failed to load inbox. Please try again.` });
+      }
+    },
+  },
+};

--- a/commands/inbox.js
+++ b/commands/inbox.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDueDate, getLpcUser, findOption } = require('../util/economy');
+const { formatMoney, formatDueDate, getLpcUser, findOption, getFocusedOption, civilianAutocomplete } = require('../util/economy');
 
 const STATUS_LABEL = {
   pending: 'Pending',
@@ -20,6 +20,13 @@ module.exports = {
   },
   options: [
     {
+      name: "civilian",
+      description: "Civilian whose inbox to view",
+      type: CommandOptions.String,
+      required: true,
+      autocomplete: true,
+    },
+    {
       name: "status",
       description: "Filter by status (default: pending)",
       type: CommandOptions.String,
@@ -33,6 +40,28 @@ module.exports = {
       ],
     },
   ],
+  Autocomplete: {
+    run: async (client, interaction) => {
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
+        return interaction.respond([]);
+      }
+      const focused = getFocusedOption(interaction.data.options);
+      if (!focused || focused.name !== 'civilian') return interaction.respond([]);
+      try {
+        const choices = await civilianAutocomplete(
+          client,
+          user._id.toString(),
+          user.user.lastAccessedCommunity.communityID,
+          focused.value,
+        );
+        return interaction.respond(choices);
+      } catch (err) {
+        client.error(`/inbox autocomplete: ${err.message}`);
+        return interaction.respond([]);
+      }
+    },
+  },
   SlashCommand: {
     run: async (client, interaction, args, { GuildDB }) => {
       if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
@@ -46,14 +75,17 @@ module.exports = {
       if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID)
         return interaction.send({ content: `You must join a community to use this command.`, flags: (1 << 6) });
 
-      const userId = user._id.toString();
       const communityId = user.user.lastAccessedCommunity.communityID;
+      const civilianId = (findOption(args, 'civilian') || {}).value;
       const status = (findOption(args, 'status') || {}).value || 'pending';
+
+      if (!civilianId)
+        return interaction.send({ content: `Please pick a civilian.`, flags: (1 << 6) });
 
       await interaction.defer();
 
       try {
-        const path = `/api/v2/economy/inbox?userId=${encodeURIComponent(userId)}&communityId=${encodeURIComponent(communityId)}&limit=25` +
+        const path = `/api/v2/economy/inbox?civilianId=${encodeURIComponent(civilianId)}&communityId=${encodeURIComponent(communityId)}&limit=25` +
           (status === 'all' ? '' : `&status=${encodeURIComponent(status)}`);
         const res = await apiRequest(client, 'GET', path);
         const items = (res && res.data) || [];

--- a/commands/inbox.js
+++ b/commands/inbox.js
@@ -10,6 +10,7 @@ const {
   civilianAutocomplete,
   resolveCivilianId,
   lookupCivilianName,
+  formatInboxItemLabel,
 } = require('../util/economy');
 
 const STATUS_LABEL = {
@@ -112,8 +113,7 @@ module.exports = {
         const lines = items.slice(0, 10).map((i) => {
           const label = STATUS_LABEL[i.status] || i.status;
           const idShort = String(i._id || '').slice(-6);
-          const title = i.title || i.type || 'Item';
-          return `• \`${idShort}\` — ${formatMoney(i.amount)} — ${title} (${label}, due ${formatDueDate(i.dueAt)})`;
+          return `• \`${idShort}\` — ${formatInboxItemLabel(i)} — ${label}, due ${formatDueDate(i.dueAt)}`;
         });
 
         const totalCount = (res && res.totalCount) || items.length;

--- a/commands/pay-fine.js
+++ b/commands/pay-fine.js
@@ -1,7 +1,16 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, getLpcUser, findOption, getFocusedOption, fetchInboxChoices, civilianAutocomplete } = require('../util/economy');
+const {
+  formatMoney,
+  getLpcUser,
+  findOption,
+  getFocusedOption,
+  fetchInboxChoices,
+  civilianAutocomplete,
+  resolveCivilianId,
+  lookupCivilianName,
+} = require('../util/economy');
 
 module.exports = {
   name: "pay-fine",
@@ -12,17 +21,17 @@ module.exports = {
   },
   options: [
     {
-      name: "civilian",
-      description: "Civilian who received the fine",
+      name: "fine",
+      description: "The fine to pay",
       type: CommandOptions.String,
       required: true,
       autocomplete: true,
     },
     {
-      name: "fine",
-      description: "The fine to pay",
+      name: "civilian",
+      description: "Override your active civilian for this run",
       type: CommandOptions.String,
-      required: true,
+      required: false,
       autocomplete: true,
     },
   ],
@@ -47,7 +56,8 @@ module.exports = {
         }
       }
       if (focused.name === 'fine') {
-        const civilianId = (findOption(interaction.data.options, 'civilian') || {}).value;
+        const explicitId = (findOption(interaction.data.options, 'civilian') || {}).value || '';
+        const civilianId = await resolveCivilianId(client, userId, communityId, explicitId);
         if (!civilianId) return interaction.respond([]);
         try {
           const choices = await fetchInboxChoices(
@@ -90,11 +100,13 @@ module.exports = {
           `/api/v2/economy/inbox/${encodeURIComponent(fineId)}/pay?userId=${encodeURIComponent(userId)}`,
         );
 
+        const civName = (await lookupCivilianName(client, item.civilianId)) || 'Unknown';
         const embed = new EmbedBuilder()
           .setColor('#38bdf8')
           .setAuthor({ name: 'Fine Paid', iconURL: client.config.IconURL })
           .setTitle(item.title || item.type || 'Paid')
           .addFields(
+            { name: '**Civilian**', value: `\`${civName}\``, inline: true },
             { name: '**Amount**', value: `\`${formatMoney(item.amount)}\``, inline: true },
             { name: '**Status**', value: `\`${item.status || 'paid'}\``, inline: true },
           );

--- a/commands/pay-fine.js
+++ b/commands/pay-fine.js
@@ -111,6 +111,15 @@ module.exports = {
             { name: '**Status**', value: `\`${item.status || 'paid'}\``, inline: true },
           );
 
+        const chargeLines = (item.charges || [])
+          .filter((c) => c && c.label && c.status !== 'dismissed')
+          .map((c) => `• ${c.label} — ${formatMoney(c.amount)}`);
+        if (chargeLines.length > 0) {
+          embed.addFields({ name: '**Charges**', value: chargeLines.join('\n').slice(0, 1024) });
+        } else if (item.body) {
+          embed.addFields({ name: '**Details**', value: String(item.body).slice(0, 1024) });
+        }
+
         return interaction.editOriginal({ embeds: [embed] });
       } catch (err) {
         const msg = err && err.message ? err.message : String(err);

--- a/commands/pay-fine.js
+++ b/commands/pay-fine.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, getLpcUser, findOption, getFocusedOption, fetchInboxChoices } = require('../util/economy');
+const { formatMoney, getLpcUser, findOption, getFocusedOption, fetchInboxChoices, civilianAutocomplete } = require('../util/economy');
 
 module.exports = {
   name: "pay-fine",
@@ -11,6 +11,13 @@ module.exports = {
     member: [],
   },
   options: [
+    {
+      name: "civilian",
+      description: "Civilian who received the fine",
+      type: CommandOptions.String,
+      required: true,
+      autocomplete: true,
+    },
     {
       name: "fine",
       description: "The fine to pay",
@@ -25,16 +32,38 @@ module.exports = {
       if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
         return interaction.respond([]);
       }
+      const userId = user._id.toString();
+      const communityId = user.user.lastAccessedCommunity.communityID;
       const focused = getFocusedOption(interaction.data.options);
-      if (!focused || focused.name !== 'fine') return interaction.respond([]);
-      const choices = await fetchInboxChoices(
-        client,
-        user._id.toString(),
-        user.user.lastAccessedCommunity.communityID,
-        focused.value,
-        ['pending', 'delinquent', 'contested'],
-      );
-      return interaction.respond(choices);
+      if (!focused) return interaction.respond([]);
+
+      if (focused.name === 'civilian') {
+        try {
+          const choices = await civilianAutocomplete(client, userId, communityId, focused.value);
+          return interaction.respond(choices);
+        } catch (err) {
+          client.error(`/pay-fine civilian autocomplete: ${err.message}`);
+          return interaction.respond([]);
+        }
+      }
+      if (focused.name === 'fine') {
+        const civilianId = (findOption(interaction.data.options, 'civilian') || {}).value;
+        if (!civilianId) return interaction.respond([]);
+        try {
+          const choices = await fetchInboxChoices(
+            client,
+            civilianId,
+            communityId,
+            focused.value,
+            ['pending', 'delinquent', 'contested'],
+          );
+          return interaction.respond(choices);
+        } catch (err) {
+          client.error(`/pay-fine fine autocomplete: ${err.message}`);
+          return interaction.respond([]);
+        }
+      }
+      return interaction.respond([]);
     },
   },
   SlashCommand: {

--- a/commands/pay-fine.js
+++ b/commands/pay-fine.js
@@ -1,0 +1,87 @@
+const { EmbedBuilder } = require('discord.js');
+const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
+const { apiRequest } = require('../util/api');
+const { formatMoney, getLpcUser, findOption, getFocusedOption, fetchInboxChoices } = require('../util/economy');
+
+module.exports = {
+  name: "pay-fine",
+  description: "Pay a pending fine or fee from your balance",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [
+    {
+      name: "fine",
+      description: "The fine to pay",
+      type: CommandOptions.String,
+      required: true,
+      autocomplete: true,
+    },
+  ],
+  Autocomplete: {
+    run: async (client, interaction) => {
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
+        return interaction.respond([]);
+      }
+      const focused = getFocusedOption(interaction.data.options);
+      if (!focused || focused.name !== 'fine') return interaction.respond([]);
+      const choices = await fetchInboxChoices(
+        client,
+        user._id.toString(),
+        user.user.lastAccessedCommunity.communityID,
+        focused.value,
+        ['pending', 'delinquent', 'contested'],
+      );
+      return interaction.respond(choices);
+    },
+  },
+  SlashCommand: {
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
+      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });
+
+      const userId = user._id.toString();
+      const fineId = (findOption(args, 'fine') || {}).value;
+      if (!fineId) return interaction.send({ content: `Please pick a fine to pay.`, flags: (1 << 6) });
+
+      await interaction.defer();
+
+      try {
+        const item = await apiRequest(
+          client,
+          'POST',
+          `/api/v2/economy/inbox/${encodeURIComponent(fineId)}/pay?userId=${encodeURIComponent(userId)}`,
+        );
+
+        const embed = new EmbedBuilder()
+          .setColor('#38bdf8')
+          .setAuthor({ name: 'Fine Paid', iconURL: client.config.IconURL })
+          .setTitle(item.title || item.type || 'Paid')
+          .addFields(
+            { name: '**Amount**', value: `\`${formatMoney(item.amount)}\``, inline: true },
+            { name: '**Status**', value: `\`${item.status || 'paid'}\``, inline: true },
+          );
+
+        return interaction.editOriginal({ embeds: [embed] });
+      } catch (err) {
+        const msg = err && err.message ? err.message : String(err);
+        client.error(`/pay-fine error: ${msg}`);
+        if (msg.includes('(402)'))
+          return interaction.editOriginal({ content: `Insufficient balance to pay this fine.` });
+        if (msg.includes('(403)'))
+          return interaction.editOriginal({ content: `You can't pay this fine — it belongs to a different user.` });
+        if (msg.includes('(404)'))
+          return interaction.editOriginal({ content: `Fine not found.` });
+        return interaction.editOriginal({ content: `Failed to pay fine. Please try again.` });
+      }
+    },
+  },
+};

--- a/commands/set-active-civilian.js
+++ b/commands/set-active-civilian.js
@@ -1,0 +1,88 @@
+const { EmbedBuilder } = require('discord.js');
+const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
+const {
+  getLpcUser,
+  findOption,
+  getFocusedOption,
+  civilianAutocomplete,
+  setActiveCivilianId,
+  lookupCivilianName,
+} = require('../util/economy');
+
+module.exports = {
+  name: "set-active-civilian",
+  description: "Pick a default civilian for /wallet, /inbox, /clock-in, /pay-fine, /contest-fine",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [
+    {
+      name: "civilian",
+      description: "Civilian to set as your active one for this community",
+      type: CommandOptions.String,
+      required: true,
+      autocomplete: true,
+    },
+  ],
+  Autocomplete: {
+    run: async (client, interaction) => {
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
+        return interaction.respond([]);
+      }
+      const focused = getFocusedOption(interaction.data.options);
+      if (!focused || focused.name !== 'civilian') return interaction.respond([]);
+      try {
+        const choices = await civilianAutocomplete(
+          client,
+          user._id.toString(),
+          user.user.lastAccessedCommunity.communityID,
+          focused.value,
+        );
+        return interaction.respond(choices);
+      } catch (err) {
+        client.error(`/set-active-civilian autocomplete: ${err.message}`);
+        return interaction.respond([]);
+      }
+    },
+  },
+  SlashCommand: {
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
+      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });
+      if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID)
+        return interaction.send({ content: `You must join a community to use this command.`, flags: (1 << 6) });
+
+      const userId = user._id.toString();
+      const communityId = user.user.lastAccessedCommunity.communityID;
+      const civilianId = (findOption(args, 'civilian') || {}).value;
+      if (!civilianId)
+        return interaction.send({ content: `Please pick a civilian.`, flags: (1 << 6) });
+
+      await interaction.defer();
+
+      try {
+        await setActiveCivilianId(client, userId, communityId, civilianId);
+        const civName = (await lookupCivilianName(client, civilianId)) || 'Unknown';
+
+        const embed = new EmbedBuilder()
+          .setColor('#38bdf8')
+          .setAuthor({ name: 'Active Civilian Set', iconURL: client.config.IconURL })
+          .setTitle(civName)
+          .setDescription(`Future \`/wallet\`, \`/inbox\`, \`/clock-in\`, \`/pay-fine\`, and \`/contest-fine\` will default to this civilian. Pass \`civilian:\` on any command to override for that run.`);
+
+        return interaction.editOriginal({ embeds: [embed] });
+      } catch (err) {
+        client.error(`/set-active-civilian error: ${err.message}`);
+        return interaction.editOriginal({ content: `Failed to save active civilian. Please try again.` });
+      }
+    },
+  },
+};

--- a/commands/wallet.js
+++ b/commands/wallet.js
@@ -1,7 +1,18 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDuration, formatDueDate, getLpcUser, findOption, getFocusedOption, civilianName } = require('../util/economy');
+const {
+  formatMoney,
+  formatDuration,
+  formatDueDate,
+  getLpcUser,
+  findOption,
+  getFocusedOption,
+  civilianAutocomplete,
+  resolveCivilianId,
+  lookupCivilianName,
+  isCommunityEconomyEnabled,
+} = require('../util/economy');
 
 const STATUS_LABEL = {
   pending: 'Pending',
@@ -10,15 +21,6 @@ const STATUS_LABEL = {
   paid: 'Paid',
   dismissed: 'Dismissed',
 };
-
-async function listUserCivilians(client, userId, communityId) {
-  const res = await apiRequest(
-    client,
-    'GET',
-    `/api/v2/civilians/user/${userId}?active_community_id=${encodeURIComponent(communityId)}&limit=50`
-  );
-  return (res && res.data) || [];
-}
 
 module.exports = {
   name: "wallet",
@@ -30,7 +32,7 @@ module.exports = {
   options: [
     {
       name: "civilian",
-      description: "Civilian whose wallet to view (defaults to your only civilian)",
+      description: "Override your active civilian for this run",
       type: CommandOptions.String,
       required: false,
       autocomplete: true,
@@ -44,13 +46,13 @@ module.exports = {
       }
       const focused = getFocusedOption(interaction.data.options);
       if (!focused || focused.name !== 'civilian') return interaction.respond([]);
-      const q = (focused.value || '').toLowerCase();
       try {
-        const civs = await listUserCivilians(client, user._id.toString(), user.user.lastAccessedCommunity.communityID);
-        const choices = civs
-          .map((c) => ({ name: civilianName(c), value: c._id.toString() }))
-          .filter((c) => !q || c.name.toLowerCase().includes(q))
-          .slice(0, 25);
+        const choices = await civilianAutocomplete(
+          client,
+          user._id.toString(),
+          user.user.lastAccessedCommunity.communityID,
+          focused.value,
+        );
         return interaction.respond(choices);
       } catch (err) {
         client.error(`/wallet autocomplete: ${err.message}`);
@@ -73,26 +75,24 @@ module.exports = {
 
       const userId = user._id.toString();
       const communityId = user.user.lastAccessedCommunity.communityID;
+      const explicitId = (findOption(args, 'civilian') || {}).value || '';
 
       await interaction.defer();
 
       try {
-        let civilianId = (findOption(args, 'civilian') || {}).value || '';
-        if (!civilianId) {
-          const civs = await listUserCivilians(client, userId, communityId);
-          if (civs.length === 0) {
-            return interaction.editOriginal({ content: `You don't have any civilians in your active community.` });
-          }
-          if (civs.length > 1) {
-            const names = civs.slice(0, 10).map((c) => `\`${civilianName(c)}\``).join(', ');
-            return interaction.editOriginal({ content: `You have multiple civilians. Re-run \`/wallet\` and pick one: ${names}` });
-          }
-          civilianId = civs[0]._id.toString();
+        if (!(await isCommunityEconomyEnabled(client, communityId))) {
+          return interaction.editOriginal({ content: `Economy is not enabled in your community. Ask your community admin to enable this.` });
         }
 
-        const [wallet, activeSession] = await Promise.all([
+        const civilianId = await resolveCivilianId(client, userId, communityId, explicitId);
+        if (!civilianId) {
+          return interaction.editOriginal({ content: `No civilian selected. Run \`/set-active-civilian\` or pass \`civilian:\` on this command.` });
+        }
+
+        const [wallet, activeSession, civName] = await Promise.all([
           apiRequest(client, 'GET', `/api/v2/economy/wallet/${civilianId}`),
           apiRequest(client, 'GET', `/api/v2/economy/session/active?civilianId=${encodeURIComponent(civilianId)}`).catch(() => null),
+          lookupCivilianName(client, civilianId),
         ]);
 
         const recent = wallet.recentInbox || [];
@@ -103,6 +103,7 @@ module.exports = {
           .setAuthor({ name: 'Wallet', iconURL: client.config.IconURL })
           .setTitle(formatMoney(wallet.balance))
           .addFields(
+            { name: '**Civilian**', value: `\`${civName || 'Unknown'}\``, inline: true },
             { name: '**Pending Items**', value: `\`${pending.length}\``, inline: true },
           );
 

--- a/commands/wallet.js
+++ b/commands/wallet.js
@@ -1,0 +1,139 @@
+const { EmbedBuilder } = require('discord.js');
+const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
+const { apiRequest } = require('../util/api');
+const { formatMoney, formatDuration, formatDueDate, getLpcUser, findOption, getFocusedOption } = require('../util/economy');
+
+const STATUS_LABEL = {
+  pending: 'Pending',
+  contested: 'Contested',
+  delinquent: 'Delinquent',
+  paid: 'Paid',
+  dismissed: 'Dismissed',
+};
+
+async function listUserCivilians(client, userId, communityId) {
+  const res = await apiRequest(
+    client,
+    'GET',
+    `/api/v2/civilians/user/${userId}?active_community_id=${encodeURIComponent(communityId)}&limit=50`
+  );
+  return (res && res.data) || [];
+}
+
+function civilianName(civ) {
+  const d = (civ && civ.civilian) || {};
+  return `${d.firstName || ''} ${d.lastName || ''}`.trim() || 'Unnamed';
+}
+
+module.exports = {
+  name: "wallet",
+  description: "View your civilian's balance, active shift, and pending fines",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [
+    {
+      name: "civilian",
+      description: "Civilian whose wallet to view (defaults to your only civilian)",
+      type: CommandOptions.String,
+      required: false,
+      autocomplete: true,
+    },
+  ],
+  Autocomplete: {
+    run: async (client, interaction) => {
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user || !user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) {
+        return interaction.respond([]);
+      }
+      const focused = getFocusedOption(interaction.data.options);
+      if (!focused || focused.name !== 'civilian') return interaction.respond([]);
+      const q = (focused.value || '').toLowerCase();
+      try {
+        const civs = await listUserCivilians(client, user._id.toString(), user.user.lastAccessedCommunity.communityID);
+        const choices = civs
+          .map((c) => ({ name: civilianName(c), value: c._id.toString() }))
+          .filter((c) => !q || c.name.toLowerCase().includes(q))
+          .slice(0, 25);
+        return interaction.respond(choices);
+      } catch (err) {
+        client.error(`/wallet autocomplete: ${err.message}`);
+        return interaction.respond([]);
+      }
+    },
+  },
+  SlashCommand: {
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
+      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+
+      const user = await getLpcUser(client, interaction.member.user.id);
+      if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });
+      if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID)
+        return interaction.send({ content: `You must join a community to use this command.`, flags: (1 << 6) });
+
+      const userId = user._id.toString();
+      const communityId = user.user.lastAccessedCommunity.communityID;
+
+      await interaction.defer();
+
+      try {
+        let civilianId = (findOption(args, 'civilian') || {}).value || '';
+        if (!civilianId) {
+          const civs = await listUserCivilians(client, userId, communityId);
+          if (civs.length === 0) {
+            return interaction.editOriginal({ content: `You don't have any civilians in your active community.` });
+          }
+          if (civs.length > 1) {
+            const names = civs.slice(0, 10).map((c) => `\`${civilianName(c)}\``).join(', ');
+            return interaction.editOriginal({ content: `You have multiple civilians. Re-run \`/wallet\` and pick one: ${names}` });
+          }
+          civilianId = civs[0]._id.toString();
+        }
+
+        const [wallet, activeSession] = await Promise.all([
+          apiRequest(client, 'GET', `/api/v2/economy/wallet/${civilianId}`),
+          apiRequest(client, 'GET', `/api/v2/economy/session/active?civilianId=${encodeURIComponent(civilianId)}`).catch(() => null),
+        ]);
+
+        const recent = wallet.recentInbox || [];
+        const pending = recent.filter((i) => i.status === 'pending' || i.status === 'delinquent' || i.status === 'contested');
+
+        const embed = new EmbedBuilder()
+          .setColor('#38bdf8')
+          .setAuthor({ name: 'Wallet', iconURL: client.config.IconURL })
+          .setTitle(formatMoney(wallet.balance))
+          .addFields(
+            { name: '**Pending Items**', value: `\`${pending.length}\``, inline: true },
+          );
+
+        if (activeSession && activeSession.status === 'active') {
+          const elapsed = Date.now() - new Date(activeSession.startedAt).getTime();
+          embed.addFields(
+            { name: '**Active Shift**', value: `\`${activeSession.departmentName || 'Unknown dept'}\``, inline: true },
+            { name: '**On Duty For**', value: `\`${formatDuration(elapsed)}\``, inline: true },
+          );
+        } else {
+          embed.addFields({ name: '**Active Shift**', value: '`Off duty`', inline: true });
+        }
+
+        if (pending.length > 0) {
+          const lines = pending.slice(0, 5).map((i) => {
+            const label = STATUS_LABEL[i.status] || i.status;
+            return `• ${formatMoney(i.amount)} — ${i.title || i.type || 'Fine'} (${label}, due ${formatDueDate(i.dueAt)})`;
+          });
+          embed.addFields({ name: '**Recent Pending**', value: lines.join('\n') });
+        }
+
+        return interaction.editOriginal({ embeds: [embed] });
+      } catch (err) {
+        client.error(`/wallet error: ${err.message}`);
+        return interaction.editOriginal({ content: `Failed to load wallet. Please try again.` });
+      }
+    },
+  },
+};

--- a/commands/wallet.js
+++ b/commands/wallet.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const { apiRequest } = require('../util/api');
-const { formatMoney, formatDuration, formatDueDate, getLpcUser, findOption, getFocusedOption } = require('../util/economy');
+const { formatMoney, formatDuration, formatDueDate, getLpcUser, findOption, getFocusedOption, civilianName } = require('../util/economy');
 
 const STATUS_LABEL = {
   pending: 'Pending',
@@ -18,11 +18,6 @@ async function listUserCivilians(client, userId, communityId) {
     `/api/v2/civilians/user/${userId}?active_community_id=${encodeURIComponent(communityId)}&limit=50`
   );
   return (res && res.data) || [];
-}
-
-function civilianName(civ) {
-  const d = (civ && civ.civilian) || {};
-  return `${d.firstName || ''} ${d.lastName || ''}`.trim() || 'Unnamed';
 }
 
 module.exports = {

--- a/commands/wallet.js
+++ b/commands/wallet.js
@@ -12,6 +12,7 @@ const {
   resolveCivilianId,
   lookupCivilianName,
   isCommunityEconomyEnabled,
+  formatInboxItemLabel,
 } = require('../util/economy');
 
 const STATUS_LABEL = {
@@ -120,7 +121,7 @@ module.exports = {
         if (pending.length > 0) {
           const lines = pending.slice(0, 5).map((i) => {
             const label = STATUS_LABEL[i.status] || i.status;
-            return `• ${formatMoney(i.amount)} — ${i.title || i.type || 'Fine'} (${label}, due ${formatDueDate(i.dueAt)})`;
+            return `• ${formatInboxItemLabel(i)} — ${label}, due ${formatDueDate(i.dueAt)}`;
           });
           embed.addFields({ name: '**Recent Pending**', value: lines.join('\n') });
         }

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,13 +1,15 @@
 module.exports = async (client, interaction) => {
-  if (interaction.isCommand()) return;
-
-  /*
-    This file hanldes all button interactions from any command
-  */
+  // Only handle button / select-menu interactions here. Slash commands and
+  // autocomplete are dispatched from the raw INTERACTION_CREATE WS handler
+  // in structures/LinesPoliceCadBot.js, and would otherwise crash below
+  // because they have no `customId`.
+  if (!interaction.isMessageComponent || !interaction.isMessageComponent()) return;
+  if (!interaction.customId) return;
 
   let GuildDB = await client.GetGuild(interaction.guildId);
   const interactionName = interaction.customId.split("-")[0];
   let interactionHandler = client.interactionHandlers.get(interactionName);
+  if (!interactionHandler) return;
 
   interactionHandler.run(client, interaction, GuildDB);
 };

--- a/structures/LinesPoliceCadBot.js
+++ b/structures/LinesPoliceCadBot.js
@@ -35,6 +35,34 @@ class LinesPoliceCadBot extends Client {
     // });
 
     this.ws.on("INTERACTION_CREATE", async (interaction) => {
+      // APPLICATION_COMMAND_AUTOCOMPLETE
+      if (interaction.type === 4) {
+        const command = interaction.data.name.toLowerCase();
+        const cmd = client.commands.get(command);
+        if (!cmd || !cmd.Autocomplete || typeof cmd.Autocomplete.run !== "function") {
+          return;
+        }
+        interaction.respond = async (choices) => {
+          const rest = new REST({ version: "10" }).setToken(client.config.Token);
+          return await rest.post(
+            Routes.interactionCallback(interaction.id, interaction.token),
+            {
+              body: {
+                type: 8, // APPLICATION_COMMAND_AUTOCOMPLETE_RESULT
+                data: { choices: (choices || []).slice(0, 25) },
+              },
+            },
+          );
+        };
+        try {
+          await cmd.Autocomplete.run(this, interaction);
+        } catch (err) {
+          this.error(`Autocomplete error (${command}): ${err && err.message ? err.message : err}`);
+          try { await interaction.respond([]); } catch (_) {}
+        }
+        return;
+      }
+
       if (interaction.type != 3) {
         let GuildDB = await this.GetGuild(interaction.guild_id);
 

--- a/util/economy.js
+++ b/util/economy.js
@@ -66,6 +66,54 @@ async function getLpcUser(client, discordUserId) {
     .findOne({ "user.discord.id": discordUserId });
 }
 
+const ACTIVE_CIV_COLLECTION = 'bot_active_civilians';
+
+/**
+ * Read the persisted "active civilian" the user picked via /set-active-civilian
+ * for the given community. Returns null when not set.
+ */
+async function getActiveCivilianId(client, userId, communityId) {
+  const doc = await client.dbo
+    .collection(ACTIVE_CIV_COLLECTION)
+    .findOne({ userId, communityId });
+  return doc && doc.civilianId ? doc.civilianId : null;
+}
+
+/**
+ * Persist the user's active civilian for a community. Upsert on (userId, communityId).
+ */
+async function setActiveCivilianId(client, userId, communityId, civilianId) {
+  return client.dbo.collection(ACTIVE_CIV_COLLECTION).updateOne(
+    { userId, communityId },
+    {
+      $set: { userId, communityId, civilianId, updatedAt: new Date() },
+    },
+    { upsert: true },
+  );
+}
+
+/**
+ * Resolve the civilian to act on. Returns the explicit pick if provided,
+ * otherwise the user's saved active civilian for the community, otherwise null.
+ */
+async function resolveCivilianId(client, userId, communityId, explicitId) {
+  if (explicitId) return explicitId;
+  return getActiveCivilianId(client, userId, communityId);
+}
+
+/**
+ * Look up a civilian's name by id from the civilians collection. Returns null
+ * when not found / id is invalid.
+ */
+async function lookupCivilianName(client, civilianId) {
+  if (!civilianId) return null;
+  const ObjectId = require('mongodb').ObjectId;
+  let oid;
+  try { oid = new ObjectId(civilianId); } catch (_) { return null; }
+  const doc = await client.dbo.collection('civilians').findOne({ _id: oid });
+  return doc ? civilianName(doc) : null;
+}
+
 /**
  * List a user's civilians in a community via the v2 API.
  */
@@ -89,6 +137,19 @@ async function civilianAutocomplete(client, userId, communityId, query) {
     .map((c) => ({ name: civilianName(c), value: c._id.toString() }))
     .filter((c) => !q || c.name.toLowerCase().includes(q))
     .slice(0, 25);
+}
+
+/**
+ * Returns true when community-level economy is enabled. Reads Mongo directly.
+ */
+async function isCommunityEconomyEnabled(client, communityId) {
+  const ObjectId = require('mongodb').ObjectId;
+  let oid;
+  try { oid = new ObjectId(communityId); } catch (_) { return false; }
+  const community = await client.dbo.collection('communities').findOne({ _id: oid });
+  if (!community) return false;
+  const cd = community.community || {};
+  return !!(cd.economy && cd.economy.enabled === true);
 }
 
 /**
@@ -176,4 +237,9 @@ module.exports = {
   listClockableDepartments,
   listUserCivilians,
   civilianAutocomplete,
+  getActiveCivilianId,
+  setActiveCivilianId,
+  resolveCivilianId,
+  lookupCivilianName,
+  isCommunityEconomyEnabled,
 };

--- a/util/economy.js
+++ b/util/economy.js
@@ -67,6 +67,18 @@ async function getLpcUser(client, discordUserId) {
 }
 
 /**
+ * Resolve a civilian's display name. Older docs only have `name`; newer ones
+ * have `firstName`/`lastName`.
+ */
+function civilianName(civ) {
+  const d = (civ && civ.civilian) || {};
+  const composed = `${d.firstName || ''} ${d.lastName || ''}`.trim();
+  if (composed) return composed;
+  if (d.name && d.name.trim()) return d.name.trim();
+  return 'Unnamed';
+}
+
+/**
  * Build autocomplete choices for an inbox-item picker.
  * @param {object} client Bot client (for apiRequest)
  * @param {string} userId LPC user _id
@@ -108,4 +120,5 @@ module.exports = {
   findOption,
   getLpcUser,
   fetchInboxChoices,
+  civilianName,
 };

--- a/util/economy.js
+++ b/util/economy.js
@@ -67,6 +67,31 @@ async function getLpcUser(client, discordUserId) {
 }
 
 /**
+ * List a user's civilians in a community via the v2 API.
+ */
+async function listUserCivilians(client, userId, communityId) {
+  const { apiRequest } = require('./api');
+  const res = await apiRequest(
+    client,
+    'GET',
+    `/api/v2/civilians/user/${userId}?active_community_id=${encodeURIComponent(communityId)}&limit=50`
+  );
+  return (res && res.data) || [];
+}
+
+/**
+ * Build civilian autocomplete choices filtered by typed query.
+ */
+async function civilianAutocomplete(client, userId, communityId, query) {
+  const civs = await listUserCivilians(client, userId, communityId);
+  const q = (query || '').toLowerCase();
+  return civs
+    .map((c) => ({ name: civilianName(c), value: c._id.toString() }))
+    .filter((c) => !q || c.name.toLowerCase().includes(q))
+    .slice(0, 25);
+}
+
+/**
  * List the departments a user can /clock-in to. Filters to:
  *  - community.economy.enabled === true
  *  - department.economyEnabled === true
@@ -149,4 +174,6 @@ module.exports = {
   fetchInboxChoices,
   civilianName,
   listClockableDepartments,
+  listUserCivilians,
+  civilianAutocomplete,
 };

--- a/util/economy.js
+++ b/util/economy.js
@@ -1,0 +1,111 @@
+/**
+ * Shared helpers for the /wallet, /clock-in, /clock-out, /inbox, /pay-fine,
+ * and /contest-fine commands.
+ */
+
+function formatMoney(cents) {
+  const n = Number(cents) || 0;
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  const dollars = Math.floor(abs / 100);
+  const remainder = abs % 100;
+  const padded = remainder < 10 ? `0${remainder}` : `${remainder}`;
+  return `${sign}$${dollars.toLocaleString()}.${padded}`;
+}
+
+function formatDuration(ms) {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function formatDueDate(value) {
+  if (!value) return "no due date";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "no due date";
+  return d.toLocaleDateString();
+}
+
+/**
+ * Find the option the user is currently typing in an autocomplete request.
+ * Recurses into subcommand option arrays.
+ */
+function getFocusedOption(options) {
+  for (const opt of options || []) {
+    if (opt.focused) return opt;
+    if (Array.isArray(opt.options)) {
+      const f = getFocusedOption(opt.options);
+      if (f) return f;
+    }
+  }
+  return null;
+}
+
+function findOption(options, name) {
+  for (const opt of options || []) {
+    if (opt.name === name) return opt;
+    if (Array.isArray(opt.options)) {
+      const f = findOption(opt.options, name);
+      if (f) return f;
+    }
+  }
+  return null;
+}
+
+/**
+ * Load the LPC user document for a Discord member. Returns null when the user
+ * has not connected their Discord account.
+ */
+async function getLpcUser(client, discordUserId) {
+  return client.dbo
+    .collection("users")
+    .findOne({ "user.discord.id": discordUserId });
+}
+
+/**
+ * Build autocomplete choices for an inbox-item picker.
+ * @param {object} client Bot client (for apiRequest)
+ * @param {string} userId LPC user _id
+ * @param {string} communityId Active community id
+ * @param {string} query Currently-typed filter text
+ * @param {string[]} statuses Statuses to include (e.g., ['pending','delinquent'])
+ */
+async function fetchInboxChoices(client, userId, communityId, query, statuses) {
+  const { apiRequest } = require('./api');
+  const q = (query || '').toLowerCase();
+  const all = [];
+  for (const status of statuses) {
+    const path = `/api/v2/economy/inbox?userId=${encodeURIComponent(userId)}&communityId=${encodeURIComponent(communityId)}&status=${encodeURIComponent(status)}&limit=25`;
+    try {
+      const res = await apiRequest(client, 'GET', path);
+      const items = (res && res.data) || [];
+      for (const i of items) all.push(i);
+    } catch (err) {
+      client.error(`fetchInboxChoices(${status}): ${err.message}`);
+    }
+  }
+  return all
+    .map((i) => {
+      const id = String(i._id || '');
+      const title = i.title || i.type || 'Item';
+      const label = `${formatMoney(i.amount)} — ${title}`.slice(0, 100);
+      return { name: label, value: id, _searchKey: `${title} ${id}`.toLowerCase() };
+    })
+    .filter((c) => !q || c._searchKey.includes(q))
+    .slice(0, 25)
+    .map(({ _searchKey, ...rest }) => rest);
+}
+
+module.exports = {
+  formatMoney,
+  formatDuration,
+  formatDueDate,
+  getFocusedOption,
+  findOption,
+  getLpcUser,
+  fetchInboxChoices,
+};

--- a/util/economy.js
+++ b/util/economy.js
@@ -67,6 +67,33 @@ async function getLpcUser(client, discordUserId) {
 }
 
 /**
+ * List the departments a user can /clock-in to. Filters to:
+ *  - community.economy.enabled === true
+ *  - department.economyEnabled === true
+ *  - public department (approvalRequired === false) OR user is approved member
+ *
+ * Reads directly from Mongo since the v2 `/my-departments` endpoint does not
+ * expose economy fields.
+ */
+async function listClockableDepartments(client, communityId, userId) {
+  const ObjectId = require('mongodb').ObjectId;
+  let oid;
+  try { oid = new ObjectId(communityId); } catch (_) { return []; }
+  const community = await client.dbo.collection('communities').findOne({ _id: oid });
+  if (!community) return [];
+  const cd = community.community || {};
+  if (!cd.economy || cd.economy.enabled !== true) return [];
+  const departments = cd.departments || [];
+
+  return departments.filter((d) => {
+    if (!d.economyEnabled) return false;
+    if (!d.approvalRequired) return true;
+    const members = d.members || [];
+    return members.some((m) => m.userID === userId && m.status === 'approved');
+  });
+}
+
+/**
  * Resolve a civilian's display name. Older docs only have `name`; newer ones
  * have `firstName`/`lastName`.
  */
@@ -121,4 +148,5 @@ module.exports = {
   getLpcUser,
   fetchInboxChoices,
   civilianName,
+  listClockableDepartments,
 };

--- a/util/economy.js
+++ b/util/economy.js
@@ -131,19 +131,19 @@ function civilianName(civ) {
 }
 
 /**
- * Build autocomplete choices for an inbox-item picker.
+ * Build autocomplete choices for an inbox-item picker, scoped to one civilian.
  * @param {object} client Bot client (for apiRequest)
- * @param {string} userId LPC user _id
+ * @param {string} civilianId Civilian whose inbox to query
  * @param {string} communityId Active community id
  * @param {string} query Currently-typed filter text
  * @param {string[]} statuses Statuses to include (e.g., ['pending','delinquent'])
  */
-async function fetchInboxChoices(client, userId, communityId, query, statuses) {
+async function fetchInboxChoices(client, civilianId, communityId, query, statuses) {
   const { apiRequest } = require('./api');
   const q = (query || '').toLowerCase();
   const all = [];
   for (const status of statuses) {
-    const path = `/api/v2/economy/inbox?userId=${encodeURIComponent(userId)}&communityId=${encodeURIComponent(communityId)}&status=${encodeURIComponent(status)}&limit=25`;
+    const path = `/api/v2/economy/inbox?civilianId=${encodeURIComponent(civilianId)}&communityId=${encodeURIComponent(communityId)}&status=${encodeURIComponent(status)}&limit=25`;
     try {
       const res = await apiRequest(client, 'GET', path);
       const items = (res && res.data) || [];

--- a/util/economy.js
+++ b/util/economy.js
@@ -216,13 +216,61 @@ async function fetchInboxChoices(client, civilianId, communityId, query, statuse
   return all
     .map((i) => {
       const id = String(i._id || '');
-      const title = i.title || i.type || 'Item';
-      const label = `${formatMoney(i.amount)} — ${title}`.slice(0, 100);
-      return { name: label, value: id, _searchKey: `${title} ${id}`.toLowerCase() };
+      const label = formatInboxItemLabel(i);
+      const searchHay = `${i.title || ''} ${i.body || ''} ${(i.charges || []).map((c) => c.label).join(' ')} ${id}`.toLowerCase();
+      return { name: label, value: id, _searchKey: searchHay };
     })
     .filter((c) => !q || c._searchKey.includes(q))
     .slice(0, 25)
     .map(({ _searchKey, ...rest }) => rest);
+}
+
+/**
+ * Build a Discord-friendly label for an inbox item that surfaces what the
+ * charge is actually for. Examples:
+ *   "$250.00 — Citation: Speeding 25+, No Plates"
+ *   "$150.00 — Admin fee: Late library book"
+ *   "$50.00 — Verdict (due 5/22)"
+ *
+ * Capped at 100 chars (Discord's autocomplete name limit).
+ */
+function formatInboxItemLabel(item) {
+  const amount = formatMoney(item && item.amount);
+  const sourceLabel = (() => {
+    switch (item && item.source) {
+      case 'citation': return 'Citation';
+      case 'admin': return 'Admin fee';
+      case 'judicial': return 'Verdict';
+      case 'shop': return 'Purchase';
+      case 'system': return 'System';
+      default: return (item && item.title) || (item && item.type) || 'Item';
+    }
+  })();
+
+  let detail = '';
+  const charges = (item && item.charges) || [];
+  if (charges.length > 0) {
+    const labels = charges
+      .filter((c) => c && c.status !== 'dismissed' && c.label)
+      .map((c) => c.label);
+    if (labels.length > 0) detail = labels.join(', ');
+  }
+  if (!detail && item && item.title) detail = item.title;
+  if (!detail && item && item.body) detail = item.body;
+
+  let label = detail ? `${amount} — ${sourceLabel}: ${detail}` : `${amount} — ${sourceLabel}`;
+
+  // Add a due-date hint when there's space.
+  if (item && item.dueAt) {
+    const d = new Date(item.dueAt);
+    if (!Number.isNaN(d.getTime())) {
+      const hint = ` (due ${d.getMonth() + 1}/${d.getDate()})`;
+      if (label.length + hint.length <= 100) label += hint;
+    }
+  }
+
+  if (label.length > 100) label = `${label.slice(0, 97)}...`;
+  return label;
 }
 
 module.exports = {
@@ -242,4 +290,5 @@ module.exports = {
   resolveCivilianId,
   lookupCivilianName,
   isCommunityEconomyEnabled,
+  formatInboxItemLabel,
 };


### PR DESCRIPTION
## Summary

Adds Discord parity for the v2 economy feature so users can manage shifts and fines without leaving Discord, plus the supporting infrastructure for slash-command autocomplete and a per-community "active civilian" preference so users don't have to pick a civilian on every command.

### New commands
- `/wallet [civilian]` — balance, active shift, pending items
- `/clock-in <department> [civilian]` — start a shift; department/civilian via autocomplete
- `/clock-out` — end the active shift
- `/inbox [civilian] [status]` — list fines/fees (defaults to pending)
- `/pay-fine <fine> [civilian]` — pay a fine from balance
- `/contest-fine <fine> <reason> [civilian]` — contest a fine; extends due date
- `/set-active-civilian <civilian>` — persist your default civilian per community

### Infrastructure
- `LinesPoliceCadBot.js` now dispatches `INTERACTION_CREATE` type 4 (autocomplete) to a new `cmd.Autocomplete.run` hook.
- `events/interactionCreate.js` was crashing on every autocomplete interaction (`customId.split` on undefined) — guarded to message components only.
- New `bot_active_civilians` Mongo collection (upserted on `{ userId, communityId }`) backs `/set-active-civilian`. All economy commands treat `civilian:` as an override — falling back to the saved active civilian — and every result embed shows which civilian the action ran under.
- Shared helpers live in `util/economy.js`: money/duration/date formatting, focused-option finder, civilian + department autocomplete sources, civilian name lookup, active-civilian persistence, and a community-economy-enabled check.

### Eligibility & error messages
- `/clock-in` department autocomplete reads the community doc directly from Mongo and filters to departments where: `community.economy.enabled` AND `department.economyEnabled` AND (public department OR user is an approved member). Matches the eligibility check in `economy.ClockInHandler`.
- `/clock-in` pre-checks the same eligibility before hitting the API and returns a verbose admin-help message when nothing qualifies (or the picked dept no longer qualifies). The 403 branch from the API returns the same help string.
- `/wallet` returns `Economy is not enabled in your community. Ask your community admin to enable this.` when `community.economy.enabled` is false.
- Civilian-name display falls back through `firstName + lastName` → `civilian.name` → `Unnamed` (older docs only have `name`).

## Test plan

### Setup
- [x] Bot redeployed and `RegisterSlashCommands` registered all 7 new commands on `ready`.
- [x] Open a Discord channel where the bot is allowed.
- [x] Confirm your account is connected (`/account`) and your active community is set.

### /set-active-civilian
- [x] `/set-active-civilian` — autocomplete shows the civilians in your active community by display name.
- [x] Pick one and confirm the embed shows the civilian name + "future commands will default to this civilian" hint.
- [x] Run it again with a different civilian; confirm the saved value updates (next `/wallet` reflects the new pick).

### /wallet
- [x] With active civilian set, run `/wallet` with no args — embed shows that civilian + balance + active shift status + recent pending items.
- [x] Run `/wallet civilian:<other>` and verify it switches to the override and doesn't change the persisted active civilian.
- [x] Toggle community economy off (admin UI) and run `/wallet` — returns the "Economy is not enabled…" message, no embed.
- [x] Clear active civilian (delete the doc in `bot_active_civilians` or never run /set-active-civilian) and `/wallet` with no args — returns the "No civilian selected. Run /set-active-civilian…" hint.

### /clock-in
- [x] Department autocomplete shows ONLY departments you can clock into (economy on at community + dept, and you're an approved member or it's public).
- [x] No optional civilian arg → uses active civilian; confirmation embed shows the right civilian + department + pay rate + payout mode + max session.
- [x] `civilian:<other>` override → confirmation embed shows the override.
- [x] Try clocking in twice in a row → friendly 409 message: "You already have an active shift. Use /clock-out first."
- [x] As a user with no eligible departments (or after toggling economy off mid-flow), `/clock-in` returns the verbose admin-help line.
- [x] Pick a department, then admin removes you from it → 403 path also returns the admin-help line.

### /clock-out
- [x] Active civilian-attached shift exists → `/clock-out` ends it; embed shows civilian, earned, and shift length.
- [x] No active shift → `You don't have an active shift to clock out of.`
- [x] Verify it now finds civilian-attached sessions (the bot reads `clock_sessions` directly rather than the API's user-level-only lookup).

### /inbox
- [x] No args, with active civilian set → lists pending items for that civilian; embed shows the civilian field and short IDs.
- [x] `status:Paid`, `status:Contested`, `status:Delinquent`, `status:All` — each filter works.
- [x] `civilian:<other>` override scopes to that civilian.
- [x] Civilian with no items → `No items found for <civilian> with status pending.`

### /pay-fine
- [x] `fine` autocomplete shows pending/delinquent/contested items for the active civilian (or `civilian:` override) only — not items from other civilians.
- [x] Pay a pending fine → embed shows civilian, amount, status.
- [x] Insufficient balance → `Insufficient balance to pay this fine.` (402).
- [x] Already-paid item → no double-charge; API returns the existing paid item.

### /contest-fine
- [x] `fine` autocomplete shows pending/delinquent items only (no contested/paid).
- [x] Contest a pending fine with a reason → embed shows civilian, new due date, reason.
- [x] Try contesting a fine that's already been ruled on → 400 path: "Only pending fines can be contested, and not ones already ruled on."

### Regression
- [x] `/case`, `/account`, `/panic`, `/signal-100`, `/check-status`, etc. all still work — confirms the autocomplete dispatch addition didn't break the slash-command path.
- [x] No more uncaught `customId.split` exceptions in logs when autocomplete fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)