### PR TITLE
feat(docs): GitHub Pages wiki for slash commands

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,33 @@
+name: docs-sync
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    name: commands.json is up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate docs/commands.json
+        run: node scripts/build-docs.js
+
+      - name: Fail if docs/commands.json is stale
+        run: |
+          if ! git diff --exit-code docs/commands.json; then
+            echo ""
+            echo "::error file=docs/commands.json::commands.json is stale. Run \`node scripts/build-docs.js\` locally and commit the result."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Documentation Wiki — keep it in sync
 
 The bot has a docs site served from `/docs` via GitHub Pages on `main`:
-**https://lines-police-cad.github.io/police-cad-bot/**
+**https://bot.linespolice-cad.com**
 
 The site renders command metadata from [`docs/commands.json`](./docs/commands.json), which is **generated** by [`scripts/build-docs.js`](./scripts/build-docs.js) from `commands/*.js`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# police-cad-bot — Claude instructions
+
+## Documentation Wiki — keep it in sync
+
+The bot has a docs site served from `/docs` via GitHub Pages on `main`:
+**https://lines-police-cad.github.io/police-cad-bot/**
+
+The site renders command metadata from [`docs/commands.json`](./docs/commands.json), which is **generated** by [`scripts/build-docs.js`](./scripts/build-docs.js) from `commands/*.js`.
+
+**When you add, remove, or modify any command** (anything in `commands/`), you MUST:
+
+1. Run `node scripts/build-docs.js`
+2. Commit the regenerated `docs/commands.json` alongside the command change
+
+CI will fail the PR otherwise — see [`.github/workflows/docs-sync.yml`](./.github/workflows/docs-sync.yml).
+
+For larger changes (a new command category, a new prerequisite the user must satisfy, a new failure mode), also update the **hand-written** sections of [`docs/index.html`](./docs/index.html) — the Setup guide and FAQ. The command-card list itself is generated, but the surrounding narrative isn't.
+
+## Git workflow
+
+- Feature branches: `feature/<name>`
+- Push to feature branch, open PR against `main` — never push directly
+- One-time post-merge step (Pages enablement): repo Settings → Pages → source = `main` `/docs`

--- a/README.md
+++ b/README.md
@@ -4,20 +4,13 @@
 
 The official Discord bot for [Lines Police CAD](https://linespolice-cad.com). Allows community members to interact with the CAD system directly from Discord using slash commands.
 
-## Commands
+## 📚 Documentation
 
-| Command | Description |
-|---|---|
-| `/panic` | Toggle your panic alert (creates or clears) |
-| `/signal-100` | Toggle Signal 100 for your community (activates or clears) |
-| `/update-status` | Change your dispatch status (10-8, 10-7, 10-6, etc.) |
-| `/check-status` | Check your own or another officer's status |
-| `/search` | Search civilians, vehicles, or firearms |
-| `/account` | View your connected Lines Police CAD account |
-| `/community view` | Check your active community |
-| `/channels` | View and manage which channels the bot can be used in |
-| `/roles` | Manage which roles can use the bot |
-| `/ping-on-panic` | Configure a Discord role to be pinged on panic/signal 100 |
+The full, always-up-to-date command reference, setup guide, and FAQ live on the docs site:
+
+**→ [lines-police-cad.github.io/police-cad-bot](https://lines-police-cad.github.io/police-cad-bot/)**
+
+The site is generated from the bot source — see [`docs/`](./docs/) and [`scripts/build-docs.js`](./scripts/build-docs.js). CI fails any PR that changes a command without regenerating `docs/commands.json`.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The official Discord bot for [Lines Police CAD](https://linespolice-cad.com). Al
 
 The full, always-up-to-date command reference, setup guide, and FAQ live on the docs site:
 
-**→ [lines-police-cad.github.io/police-cad-bot](https://lines-police-cad.github.io/police-cad-bot/)**
+**→ [bot.linespolice-cad.com](https://bot.linespolice-cad.com)**
 
 The site is generated from the bot source — see [`docs/`](./docs/) and [`scripts/build-docs.js`](./scripts/build-docs.js). CI fails any PR that changes a command without regenerating `docs/commands.json`.
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>404 · Lines Police CAD Bot Docs</title>
+  <meta http-equiv="refresh" content="0; url=./" />
+  <link rel="stylesheet" href="./assets/styles.css" />
+</head>
+<body style="display:grid;place-items:center;min-height:100vh;font-family:var(--font-mono);color:var(--text-muted);">
+  <p>10-9 · page not found. <a href="./">Return to dispatch →</a></p>
+</body>
+</html>

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+bot.linespolice-cad.com

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,0 +1,269 @@
+(() => {
+  "use strict";
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+  const STATE = {
+    commands: [],
+    query: "",
+    category: "All",
+  };
+
+  /* ---------- theme ---------- */
+  const themeToggle = $("#theme-toggle");
+  themeToggle?.addEventListener("click", () => {
+    const cur = document.documentElement.dataset.theme || "dark";
+    const next = cur === "dark" ? "light" : "dark";
+    document.documentElement.dataset.theme = next;
+    try { localStorage.setItem("lpc-docs-theme", next); } catch (_) {}
+  });
+
+  /* ---------- mobile nav ---------- */
+  const sidebar = $("#sidebar");
+  const menuBtn = $("#menu-btn");
+  menuBtn?.addEventListener("click", () => {
+    const open = sidebar.classList.toggle("open");
+    menuBtn.setAttribute("aria-expanded", String(open));
+  });
+  $$(".sidenav a").forEach((a) =>
+    a.addEventListener("click", () => sidebar.classList.remove("open"))
+  );
+
+  /* ---------- active section highlighting ---------- */
+  const navLinks = $$("[data-nav]");
+  const sectionIds = navLinks.map((a) => a.getAttribute("data-nav"));
+  const sectionEls = sectionIds.map((id) => document.getElementById(id)).filter(Boolean);
+
+  const setActive = (id) => {
+    navLinks.forEach((a) =>
+      a.classList.toggle("active", a.getAttribute("data-nav") === id)
+    );
+  };
+
+  if ("IntersectionObserver" in window) {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (visible) setActive(visible.target.id);
+      },
+      { rootMargin: "-30% 0px -55% 0px", threshold: [0.1, 0.5, 0.9] }
+    );
+    sectionEls.forEach((el) => obs.observe(el));
+  }
+
+  /* ---------- search keyboard shortcut ---------- */
+  const searchInput = $("#search");
+  const searchKbd = $("#search-kbd");
+  document.addEventListener("keydown", (e) => {
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (e.key === "Escape") {
+        e.target.blur();
+      }
+      return;
+    }
+    if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      searchInput?.focus();
+    }
+  });
+  searchInput?.addEventListener("focus", () => searchKbd?.setAttribute("hidden", ""));
+  searchInput?.addEventListener("blur", () => searchKbd?.removeAttribute("hidden"));
+  searchInput?.addEventListener("input", (e) => {
+    STATE.query = e.target.value.trim().toLowerCase();
+    render();
+  });
+
+  /* ---------- load commands ---------- */
+  fetch("./commands.json", { cache: "no-cache" })
+    .then((r) => r.json())
+    .then((data) => {
+      STATE.commands = (data.commands || []).filter((c) => !c.debug);
+      $("#stat-commands").textContent = STATE.commands.length;
+      $("#nav-count").textContent = STATE.commands.length;
+      buildChips();
+      render();
+    })
+    .catch((err) => {
+      console.error("Failed to load commands.json", err);
+      const list = $("#cmd-list");
+      if (list) list.innerHTML = `<p class="empty">Couldn't load commands. Try refreshing.</p>`;
+    });
+
+  /* ---------- chips ---------- */
+  function buildChips() {
+    const counts = STATE.commands.reduce((acc, c) => {
+      acc[c.category] = (acc[c.category] || 0) + 1;
+      return acc;
+    }, {});
+    const order = ["All", "Account", "Community", "Dispatch", "Economy", "Lookup", "Admin", "Info"];
+    const chips = $("#chips");
+    chips.innerHTML = "";
+    order.forEach((cat) => {
+      if (cat !== "All" && !counts[cat]) return;
+      const n = cat === "All" ? STATE.commands.length : counts[cat];
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "chip";
+      btn.setAttribute("role", "tab");
+      btn.setAttribute("aria-selected", cat === STATE.category ? "true" : "false");
+      btn.innerHTML = `${cat}<span class="chip-count">${n}</span>`;
+      btn.addEventListener("click", () => {
+        STATE.category = cat;
+        $$(".chip", chips).forEach((c) =>
+          c.setAttribute("aria-selected", c === btn ? "true" : "false")
+        );
+        render();
+      });
+      chips.appendChild(btn);
+    });
+  }
+
+  /* ---------- render ---------- */
+  function flattenOptionNames(opts) {
+    if (!Array.isArray(opts)) return [];
+    const out = [];
+    for (const o of opts) {
+      out.push(o.name);
+      out.push(...flattenOptionNames(o.options));
+    }
+    return out;
+  }
+
+  function match(cmd) {
+    if (STATE.category !== "All" && cmd.category !== STATE.category) return false;
+    if (!STATE.query) return true;
+    const hay = (
+      cmd.name +
+      " " +
+      cmd.description +
+      " " +
+      flattenOptionNames(cmd.options).join(" ")
+    ).toLowerCase();
+    return hay.includes(STATE.query);
+  }
+
+  function render() {
+    const list = $("#cmd-list");
+    const empty = $("#empty");
+    list.innerHTML = "";
+    const visible = STATE.commands.filter(match);
+    if (visible.length === 0) {
+      empty.hidden = false;
+      return;
+    }
+    empty.hidden = true;
+    const tpl = $("#cmd-card-tpl");
+    const frag = document.createDocumentFragment();
+    visible.forEach((cmd) => frag.appendChild(renderCard(cmd, tpl)));
+    list.appendChild(frag);
+  }
+
+  function renderCard(cmd, tpl) {
+    const node = tpl.content.firstElementChild.cloneNode(true);
+    node.dataset.name = cmd.name;
+    node.dataset.category = cmd.category;
+    node.style.setProperty("--cat", `var(--cat-${cmd.category})`);
+
+    $(".cmd-name", node).textContent = cmd.name;
+    $(".cmd-desc", node).textContent = cmd.description || "—";
+    $(".cmd-cat", node).textContent = cmd.category;
+
+    const optionCount = countOptions(cmd.options);
+    const meta = [
+      optionCount ? `${optionCount} opt${optionCount === 1 ? "" : "s"}` : "no options",
+    ].join(" · ");
+    $(".cmd-meta", node).textContent = meta;
+
+    // options
+    const optTree = $(".opt-tree", node);
+    if (cmd.options && cmd.options.length) {
+      cmd.options.forEach((o) => optTree.appendChild(renderOption(o)));
+    } else {
+      const empty = document.createElement("p");
+      empty.className = "perm-empty";
+      empty.textContent = "This command takes no options.";
+      optTree.appendChild(empty);
+    }
+
+    // permissions
+    const perms = $(".perm-chips", node);
+    const allPerms = [
+      ...(cmd.permissions.channel || []).map((p) => ({ label: p, scope: "Channel" })),
+      ...(cmd.permissions.member || []).map((p) => ({ label: p, scope: "Member" })),
+    ];
+    if (allPerms.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "perm-empty";
+      empty.textContent = "No extra Discord permissions required.";
+      perms.appendChild(empty);
+    } else {
+      allPerms.forEach((p) => {
+        const chip = document.createElement("span");
+        chip.className = "perm-chip";
+        chip.textContent = p.label.replace(/_/g, " ").toLowerCase();
+        chip.title = `${p.scope} permission`;
+        perms.appendChild(chip);
+      });
+    }
+
+    // expand toggle
+    const head = $(".cmd-head", node);
+    const body = $(".cmd-body", node);
+    head.addEventListener("click", () => {
+      const open = node.hasAttribute("open");
+      if (open) {
+        node.removeAttribute("open");
+        body.hidden = true;
+        head.setAttribute("aria-expanded", "false");
+      } else {
+        node.setAttribute("open", "");
+        body.hidden = false;
+        head.setAttribute("aria-expanded", "true");
+      }
+    });
+
+    return node;
+  }
+
+  function countOptions(opts) {
+    if (!Array.isArray(opts)) return 0;
+    // Count top-level options + subcommand options
+    let n = 0;
+    for (const o of opts) {
+      n += 1;
+      if (o.options) n += o.options.length;
+    }
+    return n;
+  }
+
+  function renderOption(opt) {
+    const tpl = $("#opt-row-tpl");
+    const node = tpl.content.firstElementChild.cloneNode(true);
+    $(".opt-name", node).textContent = opt.name;
+    $(".opt-type", node).textContent = opt.type;
+    const reqEl = $(".opt-req", node);
+    reqEl.textContent = opt.required ? "REQUIRED" : "OPTIONAL";
+    reqEl.classList.add(opt.required ? "req-yes" : "req-no");
+    $(".opt-desc", node).textContent = opt.description || "";
+
+    const choicesEl = $(".opt-choices", node);
+    if (opt.choices && opt.choices.length) {
+      opt.choices.forEach((c) => {
+        const span = document.createElement("span");
+        span.className = "choice";
+        span.textContent = c.name;
+        choicesEl.appendChild(span);
+      });
+    }
+
+    const childrenEl = $(".opt-children", node);
+    if (opt.options && opt.options.length) {
+      opt.options.forEach((c) => childrenEl.appendChild(renderOption(c)));
+    }
+
+    return node;
+  }
+})();

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,0 +1,888 @@
+/* =========================================================
+   Lines Police CAD — Discord Bot Docs
+   Aesthetic: dispatch console / CAD terminal — sharp brackets,
+   pulsing live dots, mono command sigils, subtle CRT grid.
+   ========================================================= */
+
+:root {
+  --font-body: "Outfit", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --font-display: "Outfit", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "Cascadia Code", Menlo, monospace;
+
+  /* dark — default */
+  --bg: #050a12;
+  --bg-2: #07101c;
+  --surface: #0a121f;
+  --surface-2: #101b2e;
+  --surface-3: #182640;
+  --border: rgba(56, 189, 248, 0.13);
+  --border-strong: rgba(56, 189, 248, 0.32);
+  --text: #e6edf6;
+  --text-muted: #9aa9bd;
+  --text-dim: #5d6c83;
+  --accent: #38bdf8;
+  --accent-2: #818cf8;
+  --accent-soft: rgba(56, 189, 248, 0.1);
+  --glow: 0 0 24px rgba(56, 189, 248, 0.18);
+  --danger: #f87171;
+  --warn: #fbbf24;
+  --ok: #34d399;
+  --grid-color: rgba(56, 189, 248, 0.05);
+  --scan-opacity: 0.025;
+
+  /* category pills */
+  --cat-Account: #818cf8;
+  --cat-Community: #c084fc;
+  --cat-Dispatch: #f87171;
+  --cat-Economy: #34d399;
+  --cat-Lookup: #38bdf8;
+  --cat-Admin: #fbbf24;
+  --cat-Info: #94a3b8;
+
+  --radius: 14px;
+  --radius-sm: 8px;
+  --shadow-1: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="light"] {
+  --bg: #f1f5fb;
+  --bg-2: #e8eef7;
+  --surface: #ffffff;
+  --surface-2: #f8fafc;
+  --surface-3: #eef2f8;
+  --border: rgba(2, 132, 199, 0.16);
+  --border-strong: rgba(2, 132, 199, 0.36);
+  --text: #0b1726;
+  --text-muted: #41526a;
+  --text-dim: #8492a8;
+  --accent: #0284c7;
+  --accent-2: #4f46e5;
+  --accent-soft: rgba(2, 132, 199, 0.09);
+  --glow: 0 0 24px rgba(2, 132, 199, 0.14);
+  --grid-color: rgba(2, 132, 199, 0.07);
+  --scan-opacity: 0;
+  --shadow-1: 0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 6px 18px rgba(15, 23, 42, 0.08);
+
+  --cat-Account: #4f46e5;
+  --cat-Community: #9333ea;
+  --cat-Dispatch: #dc2626;
+  --cat-Economy: #059669;
+  --cat-Lookup: #0284c7;
+  --cat-Admin: #d97706;
+  --cat-Info: #475569;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+html {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  scroll-behavior: smooth;
+}
+body {
+  background:
+    radial-gradient(ellipse 80% 50% at 30% -10%, rgba(56, 189, 248, 0.1), transparent 70%),
+    radial-gradient(ellipse 60% 40% at 90% 10%, rgba(129, 140, 248, 0.08), transparent 70%),
+    var(--bg);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+[data-theme="light"] body {
+  background:
+    radial-gradient(ellipse 70% 40% at 20% 0%, rgba(2, 132, 199, 0.09), transparent 70%),
+    radial-gradient(ellipse 50% 30% at 90% 8%, rgba(99, 102, 241, 0.07), transparent 70%),
+    var(--bg);
+}
+
+::selection { background: var(--accent); color: var(--bg); }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+/* ---------- atmospheric layers ---------- */
+.grid-bg {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background-image:
+    linear-gradient(to right, var(--grid-color) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--grid-color) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(ellipse at 50% 30%, black 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse at 50% 30%, black 30%, transparent 80%);
+}
+.scanlines {
+  position: fixed; inset: 0; pointer-events: none; z-index: 1;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, var(--scan-opacity)) 0,
+    rgba(255, 255, 255, var(--scan-opacity)) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: overlay;
+}
+
+/* ---------- typography primitives ---------- */
+.eyebrow {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px; font-weight: 500;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 14px;
+}
+.live-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 var(--accent);
+  animation: pulse 2.2s ease-out infinite;
+}
+@keyframes pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(56, 189, 248, 0.55); }
+  70%  { box-shadow: 0 0 0 10px rgba(56, 189, 248, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(56, 189, 248, 0); }
+}
+
+.display {
+  font-family: var(--font-display);
+  font-size: clamp(2.4rem, 5.8vw, 4.4rem);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 0.98;
+  margin: 0 0 24px;
+  color: var(--text);
+}
+.display-accent {
+  background: linear-gradient(120deg, var(--accent) 10%, var(--accent-2) 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.7rem, 3.2vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  margin: 0 0 14px;
+}
+.lede {
+  font-size: 1.125rem;
+  color: var(--text-muted);
+  max-width: 62ch;
+  margin: 0 0 36px;
+}
+.section-sub {
+  color: var(--text-muted);
+  max-width: 62ch;
+  margin: 0;
+}
+
+code, kbd, .mono { font-family: var(--font-mono); }
+.kbd-inline {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  padding: 2px 6px;
+  border-radius: 5px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+/* ---------- layout ---------- */
+.sidebar {
+  position: fixed; inset: 0 auto 0 0;
+  width: 280px;
+  padding: 28px 22px;
+  background: linear-gradient(180deg, var(--bg-2), var(--bg));
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  z-index: 30;
+}
+.sidebar-head { margin-bottom: 30px; }
+.brand {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--text); text-decoration: none;
+}
+.brand img {
+  border-radius: 10px;
+  background: var(--surface-2);
+  padding: 4px;
+  border: 1px solid var(--border);
+}
+.brand-text { display: flex; flex-direction: column; line-height: 1.2; }
+.brand-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+.brand-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+
+.sidenav { display: flex; flex-direction: column; gap: 2px; flex: 1; }
+.sidenav a {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  border: 1px solid transparent;
+  transition: background 120ms, color 120ms, border-color 120ms;
+}
+.sidenav a:hover { color: var(--text); background: var(--surface-2); text-decoration: none; }
+.sidenav a.active {
+  color: var(--text);
+  background: var(--accent-soft);
+  border-color: var(--border);
+}
+.sidenav a.active .dot { background: var(--accent); box-shadow: 0 0 12px var(--accent); }
+.sidenav .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--text-dim);
+  transition: background 120ms, box-shadow 120ms;
+}
+.sidenav .count {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-dim);
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+}
+
+.sidebar-foot { display: flex; flex-direction: column; gap: 14px; }
+.ext {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/* theme toggle */
+.theme-toggle {
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  border-radius: 999px;
+  padding: 4px;
+  cursor: pointer;
+  position: relative;
+  width: 100%;
+  font-family: var(--font-mono);
+}
+.theme-track {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  position: relative;
+  height: 28px;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.theme-knob {
+  position: absolute;
+  top: 2px; left: 2px;
+  width: calc(50% - 2px);
+  height: calc(100% - 4px);
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  border-radius: 999px;
+  transition: transform 220ms cubic-bezier(.22, .9, .25, 1);
+  box-shadow: 0 0 18px var(--accent-soft);
+}
+[data-theme="light"] .theme-knob { transform: translateX(100%); }
+.theme-label {
+  position: relative;
+  z-index: 1;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  font-weight: 600;
+  text-align: center;
+  color: var(--text);
+  transition: color 220ms;
+}
+[data-theme="dark"] .theme-label-dark { color: #04101e; }
+[data-theme="dark"] .theme-label-light { color: var(--text-muted); }
+[data-theme="light"] .theme-label-dark { color: var(--text-muted); }
+[data-theme="light"] .theme-label-light { color: #ffffff; }
+
+.menu-btn {
+  display: none;
+  position: fixed; top: 18px; right: 18px; z-index: 50;
+  width: 44px; height: 44px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  cursor: pointer;
+  padding: 0;
+}
+.menu-btn span {
+  display: block;
+  width: 18px; height: 2px;
+  margin: 3px auto;
+  background: var(--text);
+  border-radius: 2px;
+  transition: transform 180ms, opacity 180ms;
+}
+
+.main {
+  margin-left: 280px;
+  padding: 56px clamp(20px, 5vw, 72px) 0;
+  position: relative;
+  z-index: 2;
+}
+
+/* ---------- sections ---------- */
+.section {
+  max-width: 1100px;
+  padding: 60px 0 90px;
+  position: relative;
+  scroll-margin-top: 24px;
+}
+.section + .section { border-top: 1px solid var(--border); }
+.section-head { margin-bottom: 36px; }
+
+/* corner brackets */
+.bracket {
+  position: absolute;
+  width: 22px; height: 22px;
+  border: 2px solid var(--border-strong);
+  pointer-events: none;
+  transition: border-color 200ms, transform 200ms;
+}
+.bracket-tl { top: 0; left: 0; border-right: none; border-bottom: none; }
+.bracket-br { bottom: 0; right: 0; border-left: none; border-top: none; }
+
+/* ---------- home section ---------- */
+.section-home { padding-top: 80px; }
+.section-home .bracket-tl { top: 56px; left: -14px; }
+.section-home .bracket-br { display: none; }
+
+.hero-ctas {
+  display: flex; flex-wrap: wrap; gap: 14px;
+  margin-bottom: 56px;
+}
+.btn {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 14px 22px;
+  border-radius: 12px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 0.98rem;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  transition: transform 120ms, background 160ms, border-color 160ms, box-shadow 200ms;
+  border: 1px solid transparent;
+}
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #04101e;
+  box-shadow: 0 8px 30px -8px var(--accent), 0 1px 0 rgba(255, 255, 255, 0.2) inset;
+}
+.btn-primary:hover { transform: translateY(-1px); text-decoration: none; box-shadow: 0 12px 36px -10px var(--accent); }
+.btn-ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+.btn-ghost:hover { background: var(--surface-2); border-color: var(--border-strong); text-decoration: none; }
+
+.stat-strip {
+  list-style: none; padding: 0; margin: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, var(--surface), transparent);
+  position: relative;
+  overflow: hidden;
+}
+.stat-strip::before {
+  content: ""; position: absolute; inset: 0;
+  background:
+    linear-gradient(90deg, transparent 49.5%, var(--border) 50%, transparent 50.5%),
+    linear-gradient(90deg, transparent 24.5%, var(--border) 25%, transparent 25.5%),
+    linear-gradient(90deg, transparent 74.5%, var(--border) 75%, transparent 75.5%);
+  pointer-events: none;
+  opacity: 0.6;
+}
+.stat-strip li { display: flex; flex-direction: column; gap: 4px; position: relative; z-index: 1; }
+.stat-num {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  letter-spacing: -0.03em;
+  color: var(--text);
+}
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+/* ---------- setup steps ---------- */
+.steps {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 18px;
+}
+.step {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 24px;
+  padding: 22px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  position: relative;
+  transition: border-color 180ms;
+}
+.step:hover { border-color: var(--border-strong); }
+.step-num {
+  font-family: var(--font-mono);
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+.step h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.2rem;
+  margin: 0 0 8px;
+  letter-spacing: -0.015em;
+}
+.step p { margin: 0 0 10px; color: var(--text-muted); }
+.step-body p:last-child { margin-bottom: 0; }
+.step-tip {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 10px 12px;
+  border-left: 2px solid var(--accent);
+  background: var(--accent-soft);
+  border-radius: 0 8px 8px 0;
+  font-size: 0.92rem;
+}
+.step-tip-warn { border-color: var(--warn); background: rgba(251, 191, 36, 0.08); }
+.tip-tag {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  font-weight: 700;
+  color: var(--accent);
+  padding-top: 2px;
+}
+.tip-tag-warn { color: var(--warn); }
+.optional {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+/* ---------- commands toolbar ---------- */
+.cmd-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+.search {
+  position: relative;
+  display: flex; align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0 16px;
+  transition: border-color 160ms, box-shadow 160ms;
+}
+.search:focus-within {
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.search-icon { width: 18px; height: 18px; color: var(--text-dim); flex-shrink: 0; }
+.search input {
+  flex: 1;
+  padding: 14px 12px;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.98rem;
+}
+.search input::placeholder { color: var(--text-dim); }
+.kbd {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 6px;
+  background: var(--surface-2);
+}
+
+.chips {
+  display: flex; gap: 8px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  padding-bottom: 4px;
+  scroll-snap-type: x proximity;
+}
+.chips::-webkit-scrollbar { height: 6px; }
+.chips::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+.chip {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+  padding: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 140ms, background 140ms, border-color 140ms;
+}
+.chip:hover { color: var(--text); border-color: var(--border-strong); }
+.chip[aria-selected="true"] {
+  color: #04101e;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+[data-theme="light"] .chip[aria-selected="true"] { color: #fff; }
+.chip .chip-count {
+  display: inline-block;
+  margin-left: 6px;
+  opacity: 0.65;
+  font-size: 10px;
+}
+
+/* ---------- command cards ---------- */
+.cmd-list { display: flex; flex-direction: column; gap: 12px; }
+
+.cmd-card {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: border-color 160ms, transform 160ms;
+}
+.cmd-card:hover { border-color: var(--border-strong); }
+.cmd-card:hover .bracket { border-color: var(--accent); transform: scale(1.08); }
+.cmd-card[open] { border-color: var(--border-strong); }
+
+.cmd-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  width: 100%;
+  padding: 18px 22px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  align-items: center;
+}
+.cmd-head-left { min-width: 0; }
+.cmd-name {
+  display: block;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: 1.02rem;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+.cmd-name::before { content: "/"; color: var(--accent); }
+.cmd-desc {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+.cmd-head-right {
+  display: flex; align-items: center; gap: 12px;
+  flex-shrink: 0;
+}
+.cmd-cat {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  font-weight: 600;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cat, var(--accent)) 14%, transparent);
+  color: var(--cat, var(--accent));
+  border: 1px solid color-mix(in srgb, var(--cat, var(--accent)) 28%, transparent);
+}
+.cmd-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+}
+.cmd-chevron {
+  width: 28px; height: 28px;
+  display: grid; place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  transition: transform 220ms, background 160ms;
+}
+.cmd-card[open] .cmd-chevron { transform: rotate(45deg); background: var(--accent-soft); }
+
+.cmd-body {
+  padding: 4px 22px 22px;
+  border-top: 1px dashed var(--border);
+  margin-top: 4px;
+  animation: expand 240ms cubic-bezier(.2, .9, .25, 1);
+}
+@keyframes expand {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.cmd-section + .cmd-section { margin-top: 18px; }
+.cmd-section h4 {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 16px 0 10px;
+  font-weight: 600;
+}
+
+/* option tree */
+.opt-tree { display: flex; flex-direction: column; gap: 8px; }
+.opt-row {
+  padding: 10px 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.opt-row-head {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 8px 10px;
+}
+.opt-name {
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  color: var(--text);
+  font-weight: 500;
+}
+.opt-type {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: var(--surface-3);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  text-transform: uppercase;
+}
+.opt-req {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  padding: 2px 7px;
+  border-radius: 5px;
+  font-weight: 700;
+}
+.opt-req.req-yes { background: rgba(248, 113, 113, 0.13); color: var(--danger); border: 1px solid rgba(248, 113, 113, 0.35); }
+.opt-req.req-no  { background: var(--surface-3); color: var(--text-dim); border: 1px solid var(--border); }
+.opt-desc {
+  flex: 1 1 220px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+.opt-choices {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  margin-top: 8px;
+}
+.choice {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: var(--surface-3);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+.opt-children {
+  margin-top: 8px;
+  padding-left: 14px;
+  border-left: 2px dashed var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.opt-children:empty { display: none; }
+
+/* perm chips */
+.perm-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.perm-chip {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 4px 9px;
+  border-radius: 6px;
+  background: var(--surface-2);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+.perm-empty {
+  font-size: 0.9rem;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.empty {
+  text-align: center;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  padding: 40px 0;
+}
+
+/* ---------- FAQ ---------- */
+.faq { display: flex; flex-direction: column; gap: 10px; }
+.faq details {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 20px;
+  transition: border-color 160ms;
+}
+.faq details:hover { border-color: var(--border-strong); }
+.faq details[open] { border-color: var(--border-strong); }
+.faq summary {
+  padding: 16px 0;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 1.02rem;
+  list-style: none;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::after {
+  content: "+";
+  font-family: var(--font-mono);
+  color: var(--accent);
+  transition: transform 200ms;
+}
+.faq details[open] summary::after { transform: rotate(45deg); }
+.faq p {
+  margin: 0 0 16px;
+  color: var(--text-muted);
+  font-size: 0.96rem;
+}
+
+/* ---------- support ---------- */
+.support-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 14px;
+  margin-bottom: 60px;
+}
+.support-card {
+  position: relative;
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 22px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 180ms, transform 180ms;
+  overflow: hidden;
+}
+.support-card::before {
+  content: "";
+  position: absolute; inset: auto -40% -40% auto;
+  width: 200px; height: 200px;
+  background: radial-gradient(circle, var(--accent-soft), transparent 70%);
+  opacity: 0; transition: opacity 220ms;
+}
+.support-card:hover { border-color: var(--border-strong); text-decoration: none; transform: translateY(-2px); }
+.support-card:hover::before { opacity: 1; }
+.support-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.support-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: -0.015em;
+}
+.support-sub { font-size: 0.94rem; color: var(--text-muted); }
+.support-arrow {
+  position: absolute;
+  top: 18px; right: 22px;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-size: 1.2rem;
+  transition: transform 200ms;
+}
+.support-card:hover .support-arrow { transform: translate(3px, -3px); }
+
+.site-foot {
+  border-top: 1px solid var(--border);
+  padding-top: 24px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+.site-foot a { color: var(--text-muted); }
+
+/* ---------- responsive ---------- */
+@media (max-width: 900px) {
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 220ms cubic-bezier(.2, .9, .25, 1);
+    width: 86%; max-width: 320px;
+    box-shadow: 12px 0 40px rgba(0, 0, 0, 0.4);
+  }
+  .sidebar.open { transform: translateX(0); }
+  .menu-btn { display: block; }
+  .main { margin-left: 0; padding: 76px 22px 0; }
+  .section { padding: 40px 0 60px; }
+  .stat-strip { grid-template-columns: repeat(2, 1fr); }
+  .stat-strip::before { display: none; }
+  .step { grid-template-columns: 1fr; gap: 8px; padding: 18px; }
+  .step-num { font-size: 1rem; }
+  .cmd-head { grid-template-columns: 1fr; }
+  .cmd-head-right { justify-content: flex-start; flex-wrap: wrap; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/docs/commands.json
+++ b/docs/commands.json
@@ -1,0 +1,747 @@
+{
+  "generatedAt": null,
+  "sourceFiles": 23,
+  "commands": [
+    {
+      "name": "account",
+      "description": "View connected Lines Police CAD account",
+      "category": "Account",
+      "usage": "",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": []
+    },
+    {
+      "name": "case",
+      "description": "Look up a court case by its case number",
+      "category": "Lookup",
+      "usage": "<case_number>",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "case_number",
+          "description": "Case number, e.g. CC-2026-000042",
+          "type": "String",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "channels",
+      "description": "View and manage channels the bot may be used in",
+      "category": "Admin",
+      "usage": "[opt]",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "view",
+          "description": "View allowed channels",
+          "type": "SubCommand",
+          "required": false
+        },
+        {
+          "name": "set",
+          "description": "Add a channel to allowed channels list",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "channel",
+              "description": "Channel to add to allowed channles",
+              "type": "Channel",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "description": "Remove channel from allowed channels",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "channel",
+              "description": "Channel to remove from allowed channles",
+              "type": "Channel",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "reset",
+          "description": "Reset allowed channels",
+          "type": "SubCommand",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "check-status",
+      "description": "Check your own or another officer status",
+      "category": "Dispatch",
+      "usage": "[user]",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "user",
+          "description": "Discord Username",
+          "type": "User",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "clock-in",
+      "description": "Start an on-duty shift to earn pay",
+      "category": "Economy",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "department",
+          "description": "Department to clock into",
+          "type": "String",
+          "required": true
+        },
+        {
+          "name": "civilian",
+          "description": "Override your active civilian for this shift",
+          "type": "String",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "clock-out",
+      "description": "End your active shift",
+      "category": "Economy",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": []
+    },
+    {
+      "name": "community",
+      "description": "Manage your community",
+      "category": "Community",
+      "usage": "[opt]",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "view",
+          "description": "Check your active community",
+          "type": "SubCommand",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "contest-fine",
+      "description": "Contest a pending fine; extends its due date until a judge rules",
+      "category": "Economy",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "fine",
+          "description": "The fine to contest",
+          "type": "String",
+          "required": true
+        },
+        {
+          "name": "reason",
+          "description": "Why you're contesting this fine",
+          "type": "String",
+          "required": true
+        },
+        {
+          "name": "civilian",
+          "description": "Override your active civilian for this run",
+          "type": "String",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "debug",
+      "description": "Debug for bot admin",
+      "category": "Debug",
+      "usage": "command",
+      "debug": true,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "command",
+          "description": "The debug command to execute",
+          "type": "String",
+          "required": true,
+          "choices": [
+            {
+              "name": "guild",
+              "value": "guild"
+            },
+            {
+              "name": "interaction",
+              "value": "interaction"
+            },
+            {
+              "name": "pingserver",
+              "value": "pingserver"
+            }
+          ]
+        },
+        {
+          "name": "consoleoutput",
+          "description": "Output debug messages to console (deault=false)",
+          "type": "Boolean",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "disconnect-account",
+      "description": "Disconnect your Discord account from the Lines Police CAD Database",
+      "category": "Account",
+      "usage": "",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": []
+    },
+    {
+      "name": "help",
+      "description": "Get information on a specific command",
+      "category": "Info",
+      "usage": "[command]",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "command",
+          "description": "Get information on a specific command",
+          "type": "String",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "inbox",
+      "description": "List your fines, fees, and other financial items",
+      "category": "Economy",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "civilian",
+          "description": "Override your active civilian for this run",
+          "type": "String",
+          "required": false
+        },
+        {
+          "name": "status",
+          "description": "Filter by status (default: pending)",
+          "type": "String",
+          "required": false,
+          "choices": [
+            {
+              "name": "Pending",
+              "value": "pending"
+            },
+            {
+              "name": "Contested",
+              "value": "contested"
+            },
+            {
+              "name": "Delinquent",
+              "value": "delinquent"
+            },
+            {
+              "name": "Paid",
+              "value": "paid"
+            },
+            {
+              "name": "All",
+              "value": "all"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "panic",
+      "description": "Toggle your panic alert",
+      "category": "Dispatch",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": []
+    },
+    {
+      "name": "pay-fine",
+      "description": "Pay a pending fine or fee from your balance",
+      "category": "Economy",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "fine",
+          "description": "The fine to pay",
+          "type": "String",
+          "required": true
+        },
+        {
+          "name": "civilian",
+          "description": "Override your active civilian for this run",
+          "type": "String",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "ping-on-panic",
+      "description": "Get ping on panic status",
+      "category": "Admin",
+      "usage": "",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "toggle",
+          "description": "Toggle ping on panic setting",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "toggle",
+              "description": "Toggle ping on panic",
+              "type": "Boolean",
+              "required": true
+            },
+            {
+              "name": "role",
+              "description": "Role to ping on panic",
+              "type": "Role",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "view",
+          "description": "View the current setting for ping on panic",
+          "type": "SubCommand",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "roles",
+      "description": "Manage allowed roles",
+      "category": "Admin",
+      "usage": "",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "view",
+          "description": "View allowed roles",
+          "type": "SubCommand",
+          "required": false
+        },
+        {
+          "name": "set",
+          "description": "Set an allowed role",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "role",
+              "description": "Role to add to allowed roles",
+              "type": "Role",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "remove",
+          "description": "Remove role from allowed roles",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "role",
+              "description": "Role to remove from allowed roles",
+              "type": "Role",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "search",
+      "description": "Search Names, Plates, and Firearms",
+      "category": "Lookup",
+      "usage": "[opt]",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "firearm",
+          "description": "Search firearm database",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "serial_number",
+              "description": "Firearm serial number",
+              "type": "String",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "plate",
+          "description": "Search license plate database",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "plate_number",
+              "description": "Vehicle license plate number",
+              "type": "String",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "name",
+          "description": "Search name database",
+          "type": "SubCommand",
+          "required": false,
+          "options": [
+            {
+              "name": "full_name",
+              "description": "Civilian's Full Name",
+              "type": "String",
+              "required": true
+            },
+            {
+              "name": "dob",
+              "description": "Civilian's DOB (dd/mm/yyyy)",
+              "type": "String",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "set-active-civilian",
+      "description": "Pick a default civilian for /wallet, /inbox, /clock-in, /pay-fine, /contest-fine",
+      "category": "Economy",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "civilian",
+          "description": "Civilian to set as your active one for this community",
+          "type": "String",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "signal-100",
+      "description": "Toggle Signal 100 for your community",
+      "category": "Dispatch",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": []
+    },
+    {
+      "name": "stats",
+      "description": "Displays current Bot statistics",
+      "category": "Info",
+      "usage": "",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": []
+    },
+    {
+      "name": "update-license",
+      "description": "Update Drivers License Status",
+      "category": "Lookup",
+      "usage": "[firstName] [lastName] [DOB]",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "firstname",
+          "description": "Civilian's First Name",
+          "type": "String",
+          "required": true
+        },
+        {
+          "name": "lastname",
+          "description": "Civilian's Last Name",
+          "type": "String",
+          "required": true
+        },
+        {
+          "name": "dob",
+          "description": "Civilian's DOB (yyyy-mm-dd)",
+          "type": "String",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "update-status",
+      "description": "Change User status",
+      "category": "Dispatch",
+      "usage": "[status]",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "status",
+          "description": "New Status Value",
+          "type": "String",
+          "required": true,
+          "choices": [
+            {
+              "name": "10-8 (In Service)",
+              "value": "10-8"
+            },
+            {
+              "name": "10-7 (Out of Service)",
+              "value": "10-7"
+            },
+            {
+              "name": "10-6 (Busy)",
+              "value": "10-6"
+            },
+            {
+              "name": "10-11 (Traffic Stop)",
+              "value": "10-11"
+            },
+            {
+              "name": "10-23 (Arrive on Scene",
+              "value": "10-23"
+            },
+            {
+              "name": "10-97 (In Route)",
+              "value": "10-97"
+            },
+            {
+              "name": "10-15 (Subject in Custody)",
+              "value": "10-15"
+            },
+            {
+              "name": "10-70 (Foot Pursuit)",
+              "value": "10-70"
+            },
+            {
+              "name": "10-80 (Vehicle Pursuit)",
+              "value": "10-80"
+            },
+            {
+              "name": "10-41 (Log in to CAD)",
+              "value": "10-41"
+            },
+            {
+              "name": "10-42 (Log out of CAD)",
+              "value": "10-42"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "wallet",
+      "description": "View your civilian's balance, active shift, and pending fines",
+      "category": "Economy",
+      "usage": null,
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": [
+        {
+          "name": "civilian",
+          "description": "Override your active civilian for this run",
+          "type": "String",
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,351 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Lines Police CAD · Discord Bot Docs</title>
+  <meta name="description" content="Operations brief for the Lines Police CAD Discord bot — slash commands, setup guide, and support." />
+  <meta name="theme-color" content="#050a12" />
+
+  <link rel="icon" href="https://raw.githubusercontent.com/Linesmerrill/police-cad/main/public/images/lines-police-cad-discord-logo-2024-github-profile.png" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="./assets/styles.css" />
+  <script>
+    // Apply theme before paint to avoid flash
+    (function () {
+      try {
+        var t = localStorage.getItem("lpc-docs-theme");
+        if (t === "light" || t === "dark") document.documentElement.dataset.theme = t;
+      } catch (_) {}
+    })();
+  </script>
+</head>
+<body>
+  <div class="grid-bg" aria-hidden="true"></div>
+  <div class="scanlines" aria-hidden="true"></div>
+
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar-head">
+      <a class="brand" href="#home">
+        <img src="https://raw.githubusercontent.com/Linesmerrill/police-cad/main/public/images/lines-police-cad-discord-logo-2024-github-profile.png" alt="" width="36" height="36" />
+        <div class="brand-text">
+          <span class="brand-eyebrow">LPC · UNIT 10-8</span>
+          <span class="brand-name">Bot Operations</span>
+        </div>
+      </a>
+    </div>
+    <nav class="sidenav" aria-label="Sections">
+      <a href="#home" data-nav="home"><span class="dot"></span>Overview</a>
+      <a href="#setup" data-nav="setup"><span class="dot"></span>Setup Guide</a>
+      <a href="#commands" data-nav="commands"><span class="dot"></span>Commands<span class="count" id="nav-count"></span></a>
+      <a href="#faq" data-nav="faq"><span class="dot"></span>FAQ</a>
+      <a href="#support" data-nav="support"><span class="dot"></span>Support</a>
+    </nav>
+    <div class="sidebar-foot">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle theme">
+        <span class="theme-track">
+          <span class="theme-knob"></span>
+          <span class="theme-label theme-label-dark" aria-hidden="true">DARK</span>
+          <span class="theme-label theme-label-light" aria-hidden="true">LIGHT</span>
+        </span>
+      </button>
+      <a class="ext" href="https://linespolice-cad.com" target="_blank" rel="noreferrer">
+        linespolice-cad.com <span aria-hidden="true">↗</span>
+      </a>
+    </div>
+  </aside>
+
+  <button class="menu-btn" id="menu-btn" type="button" aria-label="Toggle navigation" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
+
+  <main class="main">
+    <!-- ============================================ HOME -->
+    <section id="home" class="section section-home">
+      <div class="bracket bracket-tl" aria-hidden="true"></div>
+      <div class="bracket bracket-br" aria-hidden="true"></div>
+      <p class="eyebrow">
+        <span class="live-dot"></span>
+        TX · OPERATIONS BRIEF
+      </p>
+      <h1 class="display">
+        Lines Police CAD<br/>
+        <span class="display-accent">Discord Bot.</span>
+      </h1>
+      <p class="lede">
+        Run panic alerts, Signal 100, dispatch status, civilian look-ups, and the full economy loop —
+        without leaving Discord. Built for police-RP communities, wired into the same CAD your members already use.
+      </p>
+
+      <div class="hero-ctas">
+        <a class="btn btn-primary" href="https://linespolice-cad.com" target="_blank" rel="noreferrer">
+          Add to your server <span aria-hidden="true">→</span>
+        </a>
+        <a class="btn btn-ghost" href="#setup">
+          5-step setup
+        </a>
+      </div>
+
+      <ul class="stat-strip">
+        <li>
+          <span class="stat-num" id="stat-commands">—</span>
+          <span class="stat-label">slash commands</span>
+        </li>
+        <li>
+          <span class="stat-num">7</span>
+          <span class="stat-label">categories</span>
+        </li>
+        <li>
+          <span class="stat-num">24/7</span>
+          <span class="stat-label">in-channel</span>
+        </li>
+        <li>
+          <span class="stat-num">0</span>
+          <span class="stat-label">tab-switching</span>
+        </li>
+      </ul>
+    </section>
+
+    <!-- ============================================ SETUP -->
+    <section id="setup" class="section">
+      <header class="section-head">
+        <span class="eyebrow"><span class="live-dot"></span>02 · INITIATE LINK</span>
+        <h2 class="h2">Get the bot online in five steps</h2>
+        <p class="section-sub">
+          Each step calls out the most common error you'll hit and how to clear it. Total time: under 10 minutes.
+        </p>
+      </header>
+
+      <ol class="steps">
+        <li class="step">
+          <span class="step-num">01/</span>
+          <div class="step-body">
+            <h3>Add the bot to your server</h3>
+            <p>
+              Open the invite link from <a href="https://linespolice-cad.com" target="_blank" rel="noreferrer">linespolice-cad.com</a>
+              and select your guild. Discord will ask for the permissions <code class="kbd-inline">View Channel</code>,
+              <code class="kbd-inline">Send Messages</code>, and <code class="kbd-inline">Embed Links</code> — all required.
+            </p>
+            <p class="step-tip">
+              <span class="tip-tag">TIP</span>
+              You'll need <strong>Manage Server</strong> on your own Discord account to install bots in that guild.
+            </p>
+          </div>
+        </li>
+        <li class="step">
+          <span class="step-num">02/</span>
+          <div class="step-body">
+            <h3>Connect your Discord to Lines Police CAD</h3>
+            <p>
+              Sign in at <a href="https://linespolice-cad.com" target="_blank" rel="noreferrer">linespolice-cad.com</a>,
+              open <em>Account → Connections</em>, and link Discord. Without this, every command replies with
+              <code class="kbd-inline">You are not logged in.</code>
+            </p>
+          </div>
+        </li>
+        <li class="step">
+          <span class="step-num">03/</span>
+          <div class="step-body">
+            <h3>Join an active community</h3>
+            <p>
+              Dispatch, panic, search, and the economy stack all run against your active community. Join one on the website;
+              the bot reads it on the fly.
+            </p>
+            <p class="step-tip step-tip-warn">
+              <span class="tip-tag tip-tag-warn">WATCH FOR</span>
+              <code class="kbd-inline">You must join a community to use this command.</code>
+            </p>
+          </div>
+        </li>
+        <li class="step">
+          <span class="step-num">04/</span>
+          <div class="step-body">
+            <h3>Lock down channels &amp; roles <span class="optional">optional</span></h3>
+            <p>
+              Run <code class="kbd-inline">/channels set channel:#dispatch</code> to scope the bot to a specific channel,
+              and <code class="kbd-inline">/roles set role:@Officer</code> to gate commands behind a Discord role.
+              Both require the caller to have <em>Manage Server</em>.
+            </p>
+          </div>
+        </li>
+        <li class="step">
+          <span class="step-num">05/</span>
+          <div class="step-body">
+            <h3>Run <code class="kbd-inline">/help</code> and you're live</h3>
+            <p>
+              Type <code class="kbd-inline">/</code> in any allowed channel — every command in the table below should now
+              appear in Discord's autocomplete. Hit <code class="kbd-inline">/panic</code> to confirm the round-trip.
+            </p>
+          </div>
+        </li>
+      </ol>
+    </section>
+
+    <!-- ============================================ COMMANDS -->
+    <section id="commands" class="section">
+      <header class="section-head">
+        <span class="eyebrow"><span class="live-dot"></span>03 · COMMAND REFERENCE</span>
+        <h2 class="h2">Every slash command, in one place.</h2>
+        <p class="section-sub">
+          Pulled directly from <code class="kbd-inline">commands/*.js</code> in the bot repo. If a command changes, this list
+          rebuilds — no drift, ever.
+        </p>
+      </header>
+
+      <div class="cmd-toolbar">
+        <label class="search">
+          <svg class="search-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <circle cx="9" cy="9" r="6" stroke="currentColor" stroke-width="1.5"/>
+            <path d="m14 14 4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          <input id="search" type="search" placeholder="Search commands, options, descriptions…" autocomplete="off" spellcheck="false" />
+          <kbd class="kbd" id="search-kbd">/</kbd>
+        </label>
+        <div class="chips" id="chips" role="tablist" aria-label="Filter by category"></div>
+      </div>
+
+      <div class="cmd-list" id="cmd-list" aria-live="polite"></div>
+      <p class="empty" id="empty" hidden>No commands match that filter.</p>
+    </section>
+
+    <!-- ============================================ FAQ -->
+    <section id="faq" class="section">
+      <header class="section-head">
+        <span class="eyebrow"><span class="live-dot"></span>04 · FAQ</span>
+        <h2 class="h2">Common rejections, decoded.</h2>
+      </header>
+      <div class="faq">
+        <details>
+          <summary>"You are not logged in." — what now?</summary>
+          <p>
+            Your Discord account isn't linked to a Lines Police CAD account. Sign in at
+            <a href="https://linespolice-cad.com" target="_blank" rel="noreferrer">linespolice-cad.com</a>,
+            open <em>Account → Connections</em>, and connect Discord. Then retry the command.
+          </p>
+        </details>
+        <details>
+          <summary>"You must join a community to use this command."</summary>
+          <p>
+            Almost every command runs against your active community (dispatch status, search, economy, etc.).
+            Join one on the website, then re-run.
+          </p>
+        </details>
+        <details>
+          <summary>"You are not allowed to use the bot in this channel."</summary>
+          <p>
+            A server admin has restricted the bot via <code class="kbd-inline">/channels set</code>. Run
+            <code class="kbd-inline">/channels view</code> in any channel the bot can post in to see the allowlist,
+            or have an admin add the current channel.
+          </p>
+        </details>
+        <details>
+          <summary>"You don't have permission to use this command."</summary>
+          <p>
+            A server admin gated the bot behind specific Discord roles. Run
+            <code class="kbd-inline">/roles view</code> to see which roles are allowed.
+          </p>
+        </details>
+        <details>
+          <summary>"Economy is not enabled in your community."</summary>
+          <p>
+            The economy suite (<code class="kbd-inline">/clock-in</code>, <code class="kbd-inline">/wallet</code>,
+            <code class="kbd-inline">/inbox</code>, <code class="kbd-inline">/pay-fine</code>,
+            <code class="kbd-inline">/contest-fine</code>) requires the community owner to enable economy on the website.
+          </p>
+        </details>
+        <details>
+          <summary>"You already have an active shift. Use /clock-out first."</summary>
+          <p>
+            Only one shift can be active at a time. Run <code class="kbd-inline">/clock-out</code> to end it, then
+            <code class="kbd-inline">/clock-in</code> again for the new department.
+          </p>
+        </details>
+      </div>
+    </section>
+
+    <!-- ============================================ SUPPORT -->
+    <section id="support" class="section">
+      <header class="section-head">
+        <span class="eyebrow"><span class="live-dot"></span>05 · CONTACT</span>
+        <h2 class="h2">Need a hand? We're on the radio.</h2>
+      </header>
+      <div class="support-grid">
+        <a class="support-card" href="https://linespolice-cad.com" target="_blank" rel="noreferrer">
+          <span class="support-eyebrow">Primary</span>
+          <span class="support-title">linespolice-cad.com</span>
+          <span class="support-sub">Open the website for account, community, and billing support.</span>
+          <span class="support-arrow" aria-hidden="true">→</span>
+        </a>
+        <a class="support-card" href="https://github.com/Lines-Police-CAD/police-cad-bot/issues" target="_blank" rel="noreferrer">
+          <span class="support-eyebrow">Bugs &amp; ideas</span>
+          <span class="support-title">GitHub Issues</span>
+          <span class="support-sub">Found something broken or have a feature request? File it here.</span>
+          <span class="support-arrow" aria-hidden="true">→</span>
+        </a>
+        <a class="support-card" href="https://linespolice-cad.com" target="_blank" rel="noreferrer">
+          <span class="support-eyebrow">Support</span>
+          <span class="support-title">Contact us</span>
+          <span class="support-sub">Email and Discord support links live on the website footer.</span>
+          <span class="support-arrow" aria-hidden="true">→</span>
+        </a>
+      </div>
+
+      <footer class="site-foot">
+        <p>
+          © Lines Police CAD · Built for the dispatch desk.
+          <a href="https://linespolice-cad.com" target="_blank" rel="noreferrer">linespolice-cad.com</a>
+        </p>
+      </footer>
+    </section>
+  </main>
+
+  <!-- Command card template -->
+  <template id="cmd-card-tpl">
+    <article class="cmd-card" data-name="" data-category="">
+      <div class="bracket bracket-tl" aria-hidden="true"></div>
+      <div class="bracket bracket-br" aria-hidden="true"></div>
+      <button class="cmd-head" type="button" aria-expanded="false">
+        <div class="cmd-head-left">
+          <span class="cmd-name"></span>
+          <span class="cmd-desc"></span>
+        </div>
+        <div class="cmd-head-right">
+          <span class="cmd-cat"></span>
+          <span class="cmd-meta"></span>
+          <span class="cmd-chevron" aria-hidden="true">+</span>
+        </div>
+      </button>
+      <div class="cmd-body" hidden>
+        <div class="cmd-section cmd-options">
+          <h4>Options</h4>
+          <div class="opt-tree"></div>
+        </div>
+        <div class="cmd-section cmd-perms">
+          <h4>Required permissions</h4>
+          <div class="perm-chips"></div>
+        </div>
+      </div>
+    </article>
+  </template>
+
+  <!-- Option row template -->
+  <template id="opt-row-tpl">
+    <div class="opt-row">
+      <div class="opt-row-head">
+        <code class="opt-name"></code>
+        <span class="opt-type"></span>
+        <span class="opt-req"></span>
+        <span class="opt-desc"></span>
+      </div>
+      <div class="opt-choices"></div>
+      <div class="opt-children"></div>
+    </div>
+  </template>
+
+  <script src="./assets/app.js" defer></script>
+</body>
+</html>

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const COMMANDS_DIR = path.join(ROOT, "commands");
+const OUT_FILE = path.join(ROOT, "docs", "commands.json");
+
+const { CommandOptionTypes } = require(path.join(ROOT, "util", "CommandOptionTypes.js"));
+const TYPE_NAME_BY_ID = Object.fromEntries(
+  Object.entries(CommandOptionTypes).map(([name, id]) => [id, name])
+);
+
+const CATEGORY = {
+  account: "Account",
+  "disconnect-account": "Account",
+  community: "Community",
+  "check-status": "Dispatch",
+  "update-status": "Dispatch",
+  panic: "Dispatch",
+  "signal-100": "Dispatch",
+  "clock-in": "Economy",
+  "clock-out": "Economy",
+  wallet: "Economy",
+  inbox: "Economy",
+  "pay-fine": "Economy",
+  "contest-fine": "Economy",
+  "set-active-civilian": "Economy",
+  search: "Lookup",
+  case: "Lookup",
+  "update-license": "Lookup",
+  channels: "Admin",
+  roles: "Admin",
+  "ping-on-panic": "Admin",
+  help: "Info",
+  stats: "Info",
+  debug: "Debug",
+};
+
+function normalizeOptions(options) {
+  if (!Array.isArray(options)) return [];
+  return options.map((o) => ({
+    name: o.name,
+    description: o.description ?? "",
+    type: TYPE_NAME_BY_ID[o.type] ?? `Type(${o.type})`,
+    required: !!o.required,
+    choices: Array.isArray(o.choices)
+      ? o.choices.map((c) => ({ name: c.name, value: c.value }))
+      : undefined,
+    options: normalizeOptions(o.options),
+  })).map((o) => {
+    // drop empty arrays / undefined for compact JSON
+    if (!o.choices) delete o.choices;
+    if (!o.options || o.options.length === 0) delete o.options;
+    return o;
+  });
+}
+
+function buildCatalog() {
+  const files = fs
+    .readdirSync(COMMANDS_DIR)
+    .filter((f) => f.endsWith(".js"))
+    .sort();
+
+  const commands = [];
+  for (const file of files) {
+    const mod = require(path.join(COMMANDS_DIR, file));
+    if (!mod || !mod.name) {
+      console.warn(`[build-docs] skipping ${file}: no exported command name`);
+      continue;
+    }
+    commands.push({
+      name: mod.name,
+      description: mod.description ?? "",
+      category: CATEGORY[mod.name] ?? "Other",
+      usage: mod.usage ?? null,
+      debug: !!mod.debug,
+      permissions: {
+        channel: mod.permissions?.channel ?? [],
+        member: mod.permissions?.member ?? [],
+      },
+      options: normalizeOptions(mod.options),
+    });
+  }
+
+  commands.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    generatedAt: null,
+    sourceFiles: files.length,
+    commands,
+  };
+}
+
+function main() {
+  const catalog = buildCatalog();
+  fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
+  const json = JSON.stringify(catalog, null, 2) + "\n";
+  fs.writeFileSync(OUT_FILE, json);
+  console.log(
+    `[build-docs] wrote ${catalog.commands.length} commands to ${path.relative(ROOT, OUT_FILE)}`
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

- Single-page docs site at `/docs`, served via GitHub Pages from `main`/`/docs` (one-time setup needed after merge, see below)
- 22 user-visible slash commands rendered from auto-generated `docs/commands.json`; searchable, category-filterable, dark/light toggle, scroll-spy sidebar nav
- Setup guide, FAQ, and Support sections written from the real bot error strings
- Build script (`scripts/build-docs.js`) extracts every command's metadata from `commands/*.js`
- CI gate (`.github/workflows/docs-sync.yml`) regenerates the JSON and `git diff --exit-code`s it — **stale `commands.json` fails the PR**, drift is impossible
- README's hardcoded 10-command table is replaced with a wiki link; the old table was missing 13 commands (entire economy suite, `/case`, etc.)
- `CLAUDE.md` documents the sync rule for future contributors

<img width="1451" height="1004" alt="image" src="https://github.com/user-attachments/assets/4eba95c6-6d83-4f4d-ae44-cd1d036a819b" />


## Aesthetic

Dispatch-console direction — Outfit + JetBrains Mono, pulsing cyan LEDs, faint scan-lines, numbered section eyebrows (`01 · OPERATIONS BRIEF`), category-color-coded command card edges, corner brackets, accent-gradient theme toggle. Vanilla HTML/CSS/JS — no framework, no build step beyond the JSON regen.

## One-time post-merge step

After merging, enable Pages: **Settings → Pages → Source = `main` + `/docs`**. CI doesn't configure this for us. Site will then be live at https://lines-police-cad.github.io/police-cad-bot/.

## Test plan

- [x] Verify Pages source is set to `main` / `/docs` after merge
- [ ] Browse the live site: all 22 commands appear, search filters correctly, all 7 category chips work
- [ ] Click each command — option tree, choices, type pills, and permission chips render correctly
- [ ] Theme toggle persists across reload
- [ ] Mobile: hamburger sidebar opens, command cards stack
- [ ] Trip-test: rename a command's description on a throwaway branch, push without running the script — CI should fail with a clear message
- [ ] Lighthouse score ≥95 on Performance / Accessibility / Best Practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)