### PR TITLE
fix(docs): match real setup flow and contact links

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -401,24 +401,25 @@ code, kbd, .mono { font-family: var(--font-mono); }
   list-style: none; padding: 0; margin: 0;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px;
-  padding: 22px;
+  padding: 6px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: linear-gradient(180deg, var(--surface), transparent);
   position: relative;
   overflow: hidden;
 }
-.stat-strip::before {
-  content: ""; position: absolute; inset: 0;
-  background:
-    linear-gradient(90deg, transparent 49.5%, var(--border) 50%, transparent 50.5%),
-    linear-gradient(90deg, transparent 24.5%, var(--border) 25%, transparent 25.5%),
-    linear-gradient(90deg, transparent 74.5%, var(--border) 75%, transparent 75.5%);
-  pointer-events: none;
-  opacity: 0.6;
+.stat-strip li {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 16px 20px;
+  position: relative;
 }
-.stat-strip li { display: flex; flex-direction: column; gap: 4px; position: relative; z-index: 1; }
+.stat-strip li + li::before {
+  content: "";
+  position: absolute;
+  top: 14%; bottom: 14%; left: 0;
+  width: 1px;
+  background: var(--border);
+}
 .stat-num {
   font-family: var(--font-display);
   font-weight: 700;
@@ -496,6 +497,50 @@ code, kbd, .mono { font-family: var(--font-mono); }
   color: var(--text-dim);
   margin-left: 6px;
   vertical-align: middle;
+}
+.step-cta { margin: 6px 0 0; }
+.step-cta .btn { padding: 12px 20px; font-size: 0.94rem; }
+
+.next-steps {
+  margin-top: 22px;
+  padding: 24px 26px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(180deg, var(--accent-soft), transparent 65%),
+    var(--surface);
+}
+.next-steps .eyebrow { margin-bottom: 10px; }
+.next-steps h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.15rem;
+  letter-spacing: -0.015em;
+  margin: 0 0 8px;
+}
+.next-steps p { margin: 0 0 12px; color: var(--text-muted); }
+.next-steps ul {
+  list-style: none; padding: 0; margin: 0 0 12px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.next-steps li {
+  position: relative;
+  padding-left: 18px;
+  color: var(--text);
+  font-size: 0.96rem;
+}
+.next-steps li::before {
+  content: "▸";
+  position: absolute; left: 0; top: 0;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+.next-steps-foot {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-dim);
+  font-style: italic;
 }
 
 /* ---------- commands toolbar ---------- */

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,9 +114,10 @@
     <section id="setup" class="section">
       <header class="section-head">
         <span class="eyebrow"><span class="live-dot"></span>02 · INITIATE LINK</span>
-        <h2 class="h2">Get the bot online in five steps</h2>
+        <h2 class="h2">Get the bot online in three steps</h2>
         <p class="section-sub">
-          Each step calls out the most common error you'll hit and how to clear it. Total time: under 10 minutes.
+          Total time: under 2 minutes. Full walkthrough also lives on
+          <a href="https://www.linespolice-cad.com/discord-bot" target="_blank" rel="noreferrer">linespolice-cad.com/discord-bot</a>.
         </p>
       </header>
 
@@ -124,65 +125,56 @@
         <li class="step">
           <span class="step-num">01/</span>
           <div class="step-body">
-            <h3>Add the bot to your server</h3>
+            <h3>Add the bot to your Discord server</h3>
             <p>
-              Open the invite link from <a href="https://linespolice-cad.com" target="_blank" rel="noreferrer">linespolice-cad.com</a>
-              and select your guild. Discord will ask for the permissions <code class="kbd-inline">View Channel</code>,
-              <code class="kbd-inline">Send Messages</code>, and <code class="kbd-inline">Embed Links</code> — all required.
+              Click the button below to invite the Lines Police CAD bot. You'll need
+              <strong>Manage Server</strong> on Discord to install bots there.
             </p>
-            <p class="step-tip">
-              <span class="tip-tag">TIP</span>
-              You'll need <strong>Manage Server</strong> on your own Discord account to install bots in that guild.
+            <p class="step-cta">
+              <a class="btn btn-primary" href="https://discord.com/api/oauth2/authorize?client_id=1005557484271976569&permissions=8&scope=bot%20applications.commands" target="_blank" rel="noreferrer">
+                Add Bot to Server <span aria-hidden="true">→</span>
+              </a>
             </p>
           </div>
         </li>
         <li class="step">
           <span class="step-num">02/</span>
           <div class="step-body">
-            <h3>Connect your Discord to Lines Police CAD</h3>
+            <h3>Authorize the bot</h3>
             <p>
-              Sign in at <a href="https://linespolice-cad.com" target="_blank" rel="noreferrer">linespolice-cad.com</a>,
-              open <em>Account → Connections</em>, and link Discord. Without this, every command replies with
-              <code class="kbd-inline">You are not logged in.</code>
+              Pick the Discord server you want it in, then click <strong>Authorize</strong>.
+              Discord will add the bot with the permissions it needs to post embeds and run slash commands.
             </p>
           </div>
         </li>
         <li class="step">
           <span class="step-num">03/</span>
           <div class="step-body">
-            <h3>Join an active community</h3>
+            <h3>Connect your account</h3>
             <p>
-              Dispatch, panic, search, and the economy stack all run against your active community. Join one on the website;
-              the bot reads it on the fly.
+              Open your <a href="https://www.linespolice-cad.com/profile" target="_blank" rel="noreferrer">LPC profile</a>
+              and click <strong>Connect Discord</strong> to link your account. Every member who wants to run commands
+              has to do this for themselves.
             </p>
             <p class="step-tip step-tip-warn">
               <span class="tip-tag tip-tag-warn">WATCH FOR</span>
-              <code class="kbd-inline">You must join a community to use this command.</code>
-            </p>
-          </div>
-        </li>
-        <li class="step">
-          <span class="step-num">04/</span>
-          <div class="step-body">
-            <h3>Lock down channels &amp; roles <span class="optional">optional</span></h3>
-            <p>
-              Run <code class="kbd-inline">/channels set channel:#dispatch</code> to scope the bot to a specific channel,
-              and <code class="kbd-inline">/roles set role:@Officer</code> to gate commands behind a Discord role.
-              Both require the caller to have <em>Manage Server</em>.
-            </p>
-          </div>
-        </li>
-        <li class="step">
-          <span class="step-num">05/</span>
-          <div class="step-body">
-            <h3>Run <code class="kbd-inline">/help</code> and you're live</h3>
-            <p>
-              Type <code class="kbd-inline">/</code> in any allowed channel — every command in the table below should now
-              appear in Discord's autocomplete. Hit <code class="kbd-inline">/panic</code> to confirm the round-trip.
+              <code class="kbd-inline">You are not logged in.</code> — that error means this step isn't done yet.
             </p>
           </div>
         </li>
       </ol>
+
+      <aside class="next-steps">
+        <p class="eyebrow"><span class="live-dot"></span>NEXT · OPTIONAL</p>
+        <h3>Tune it for your server</h3>
+        <p>Once the bot is running, server admins can lock it down further:</p>
+        <ul>
+          <li><code class="kbd-inline">/channels set channel:#dispatch</code> — restrict the bot to a specific channel</li>
+          <li><code class="kbd-inline">/roles set role:@Officer</code> — gate commands behind a Discord role</li>
+          <li><code class="kbd-inline">/ping-on-panic toggle toggle:True role:@Dispatchers</code> — ping a role on panic / Signal 100</li>
+        </ul>
+        <p class="next-steps-foot">Each of these requires <em>Manage Server</em> on Discord.</p>
+      </aside>
     </section>
 
     <!-- ============================================ COMMANDS -->
@@ -274,22 +266,22 @@
         <h2 class="h2">Need a hand? We're on the radio.</h2>
       </header>
       <div class="support-grid">
-        <a class="support-card" href="https://linespolice-cad.com" target="_blank" rel="noreferrer">
-          <span class="support-eyebrow">Primary</span>
-          <span class="support-title">linespolice-cad.com</span>
-          <span class="support-sub">Open the website for account, community, and billing support.</span>
+        <a class="support-card" href="https://discord.gg/Y9ytW2ZMp4" target="_blank" rel="noreferrer">
+          <span class="support-eyebrow">Live chat</span>
+          <span class="support-title">Join the Discord</span>
+          <span class="support-sub">Real-time help from the team and other community owners.</span>
           <span class="support-arrow" aria-hidden="true">→</span>
         </a>
-        <a class="support-card" href="https://github.com/Lines-Police-CAD/police-cad-bot/issues" target="_blank" rel="noreferrer">
-          <span class="support-eyebrow">Bugs &amp; ideas</span>
-          <span class="support-title">GitHub Issues</span>
-          <span class="support-sub">Found something broken or have a feature request? File it here.</span>
+        <a class="support-card" href="https://www.linespolice-cad.com/feature-requests/new" target="_blank" rel="noreferrer">
+          <span class="support-eyebrow">Got an idea?</span>
+          <span class="support-title">Request a feature</span>
+          <span class="support-sub">Suggest a new command, integration, or quality-of-life improvement.</span>
           <span class="support-arrow" aria-hidden="true">→</span>
         </a>
-        <a class="support-card" href="https://linespolice-cad.com" target="_blank" rel="noreferrer">
-          <span class="support-eyebrow">Support</span>
-          <span class="support-title">Contact us</span>
-          <span class="support-sub">Email and Discord support links live on the website footer.</span>
+        <a class="support-card" href="https://github.com/Linesmerrill/police-cad/issues/new?assignees=&labels=&template=bug_report.md&title=" target="_blank" rel="noreferrer">
+          <span class="support-eyebrow">Something broken?</span>
+          <span class="support-title">Report a bug</span>
+          <span class="support-sub">File it on GitHub — auto-tagged and routed to the right repo.</span>
           <span class="support-arrow" aria-hidden="true">→</span>
         </a>
       </div>


### PR DESCRIPTION
## Summary

Polishes the bot wiki content with the actual onboarding flow and real contact links from linespolice-cad.com.

- **Setup** — collapsed 5 steps → the real 3-step flow:
  1. Add bot via direct OAuth link (`discord.com/api/oauth2/authorize?client_id=1005557484271976569…`)
  2. Authorize on Discord
  3. Connect via [linespolice-cad.com/profile](https://www.linespolice-cad.com/profile)

  Channels/roles moved to a *Next Steps · Optional* callout. Time estimate now ~2 min.
- **Support** — replaced placeholder cards with real links:
  - Discord support → `discord.gg/Y9ytW2ZMp4`
  - Feature requests → `linespolice-cad.com/feature-requests/new`
  - Bug reports → `github.com/Linesmerrill/police-cad/issues/new?…`
- **Copy** — "guild" → "Discord server" / "server".
- **Stat strip** — the absolute-positioned 25/50/75% dividers drifted off the content on wide screens; replaced with per-item `border-left` so dividers sit flush with each cell.

## Note on history

The content changes were originally pushed directly to \`main\` as commit \`4ad3462\` — workflow miss (post-merge of #16 the local checkout reverted to \`main\` and I didn't re-branch). That commit was reverted on \`main\` (\`6d83f4f\`) so the changes land here via PR for proper review.

## Test plan

- [ ] Open https://bot.linespolice-cad.com after merge — Setup section shows 3 steps + Next-Steps callout
- [ ] \"Add Bot to Server\" button on step 1 deep-links to the Discord OAuth screen
- [ ] All 3 support cards open the correct URLs
- [ ] Stat strip dividers align with the start of each cell on wide screens
- [ ] No remaining \"guild\" text anywhere
- [ ] Both dark and light theme look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)