### PR TITLE
ci(pages): branch-pick deploy workflow + auto-deploy on main

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,72 @@
+name: pages-deploy
+
+# Two ways this workflow runs:
+#   1. push to main → auto-deploy to bot.linespolice-cad.com
+#   2. manual run (Actions → "pages-deploy" → Run workflow → pick a branch)
+#      → deploy that branch to bot.linespolice-cad.com for testing.
+#         Production stays overwritten until you redeploy main.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site (${{ github.ref_name }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate docs/commands.json from current source
+        run: node scripts/build-docs.js
+
+      - name: Annotate what's being deployed
+        run: |
+          {
+            echo "### Deploying to bot.linespolice-cad.com"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Branch** | \`${GITHUB_REF_NAME}\` |"
+            echo "| **Commit** | \`${GITHUB_SHA:0:7}\` |"
+            echo "| **Triggered by** | ${GITHUB_EVENT_NAME} |"
+            if [ "${GITHUB_REF_NAME}" != "main" ]; then
+              echo ""
+              echo "> :warning: This is a **preview deploy from a non-main branch**. Production will stay on this branch until you re-deploy \`main\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,16 @@ CI will fail the PR otherwise — see [`.github/workflows/docs-sync.yml`](./.git
 
 For larger changes (a new command category, a new prerequisite the user must satisfy, a new failure mode), also update the **hand-written** sections of [`docs/index.html`](./docs/index.html) — the Setup guide and FAQ. The command-card list itself is generated, but the surrounding narrative isn't.
 
+## Deploying the docs site
+
+The site is deployed by [`.github/workflows/pages-deploy.yml`](./.github/workflows/pages-deploy.yml):
+
+- **Auto-deploy:** every push to `main` deploys `docs/` to https://bot.linespolice-cad.com.
+- **Preview deploy:** Actions tab → "pages-deploy" → **Run workflow** → pick any branch. That branch's `docs/` becomes the live site at `bot.linespolice-cad.com` until someone re-deploys `main` (manually or by pushing to it). Useful for testing wiki changes before merging.
+
+Pages source MUST be set to "GitHub Actions" in repo Settings → Pages (one-time configuration). Both deploy paths regenerate `docs/commands.json` from source as part of the build, so the deployed JSON always matches the deployed `commands/`.
+
 ## Git workflow
 
 - Feature branches: `feature/<name>`
 - Push to feature branch, open PR against `main` — never push directly
-- One-time post-merge step (Pages enablement): repo Settings → Pages → source = `main` `/docs`


### PR DESCRIPTION
## Summary

Replaces GitHub's built-in *Deploy from a branch* Pages source with a real workflow so we can preview any branch on the live URL before merging.

Two triggers in [`.github/workflows/pages-deploy.yml`](.github/workflows/pages-deploy.yml):

| Trigger | What it does |
|---|---|
| `push` to `main` | Auto-deploys `docs/` to https://bot.linespolice-cad.com — same end behavior as today. |
| `workflow_dispatch` | Actions tab → "pages-deploy" → **Run workflow** → pick a branch → that branch goes live. Useful for sanity-checking wiki edits before merge. |

Both paths regenerate `docs/commands.json` from `commands/*.js` as the first build step, so the deployed JSON always matches the deployed source — no chance of testing a stale wiki.

## ⚠️ One-time setup after merge

Repo Settings → Pages → **Source: GitHub Actions** (currently "Deploy from a branch"). Until that's flipped, the new workflow can't actually deploy. The `docs/CNAME` keeps `bot.linespolice-cad.com` pointed at us regardless of source.

CLAUDE.md is updated with the new deploy story.

## How to preview a branch (after merge + Pages source flip)

1. Push your branch.
2. Actions tab → **pages-deploy** → **Run workflow** → select the branch → green button.
3. ~30s later, https://bot.linespolice-cad.com serves that branch.
4. When you're done testing, run the workflow again with `main` selected (or merge your PR — push to main triggers the same workflow) to restore production.

## Test plan

- [ ] Flip Pages source to "GitHub Actions"
- [ ] First push to main after merge → auto deploy succeeds, site loads
- [ ] Run workflow manually on a feature branch with a visible change → live site reflects the branch
- [ ] Re-run on `main` → site restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)