### PR TITLE
fix(docs): hero CTA installs the bot directly; relabel 3-step

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -82,11 +82,11 @@
       </p>
 
       <div class="hero-ctas">
-        <a class="btn btn-primary" href="https://linespolice-cad.com" target="_blank" rel="noreferrer">
+        <a class="btn btn-primary" href="https://discord.com/api/oauth2/authorize?client_id=1005557484271976569&permissions=8&scope=bot%20applications.commands" target="_blank" rel="noreferrer">
           Add to your server <span aria-hidden="true">→</span>
         </a>
         <a class="btn btn-ghost" href="#setup">
-          5-step setup
+          3-step setup
         </a>
       </div>
 


### PR DESCRIPTION
## Summary

Two hero-section fixes spotted on the live site after PR #17 merged:

- **Primary CTA** "Add to your server" now opens the Discord OAuth invite flow directly (same URL as the Step 1 button in the Setup section). Before: it bounced people to linespolice-cad.com. Installing the bot is the wiki's main job, so the hero CTA should do exactly that.
- **Ghost button** label: `5-step setup` → `3-step setup` to match the actual flow.

Two-line diff in `docs/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)