### PR TITLE
fix(docs): scroll-spy bottom edge + auto-year footer

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -41,9 +41,21 @@
     );
   };
 
+  const isNearBottom = () =>
+    window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 8;
+
+  const lastSectionId = sectionEls.length ? sectionEls[sectionEls.length - 1].id : null;
+
   if ("IntersectionObserver" in window) {
     const obs = new IntersectionObserver(
       (entries) => {
+        // When the page is scrolled to the bottom, the last section can sit
+        // below the observer's active band (rootMargin) and never be flagged
+        // as visible. Force it active in that case.
+        if (lastSectionId && isNearBottom()) {
+          setActive(lastSectionId);
+          return;
+        }
         const visible = entries
           .filter((e) => e.isIntersecting)
           .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
@@ -53,6 +65,18 @@
     );
     sectionEls.forEach((el) => obs.observe(el));
   }
+
+  // Scroll/resize fallback for the bottom edge — IntersectionObserver may not
+  // re-fire if you scroll the last few pixels into view.
+  const onScrollEdge = () => {
+    if (lastSectionId && isNearBottom()) setActive(lastSectionId);
+  };
+  window.addEventListener("scroll", onScrollEdge, { passive: true });
+  window.addEventListener("resize", onScrollEdge);
+
+  /* ---------- footer year ---------- */
+  const yearEl = document.getElementById("copyright-year");
+  if (yearEl) yearEl.textContent = String(new Date().getFullYear());
 
   /* ---------- search keyboard shortcut ---------- */
   const searchInput = $("#search");

--- a/docs/index.html
+++ b/docs/index.html
@@ -288,7 +288,7 @@
 
       <footer class="site-foot">
         <p>
-          © Lines Police CAD · Built for the dispatch desk.
+          © <span id="copyright-year">2026</span> Lines Police CAD · Built for the dispatch desk.
           <a href="https://linespolice-cad.com" target="_blank" rel="noreferrer">linespolice-cad.com</a>
         </p>
       </footer>


### PR DESCRIPTION
## Summary

Two small wiki polish fixes.

- **Scroll-spy bottom edge** — when scrolled to the bottom of the page, the sidebar still highlighted *FAQ* instead of *Support* because the Support section is short enough that it sits below the IntersectionObserver's active band (`rootMargin: -30% 0px -55% 0px`). Fix: detect when the viewport is within 8px of the page bottom and force-activate the last section, both inside the observer callback and via a passive `scroll`/`resize` listener as a fallback.
- **Footer year** — hardcoded `2026` replaced with `<span id="copyright-year">` populated from `new Date().getFullYear()`. 2026 stays as the markup default in case JS doesn't run.

## Test plan

- [ ] Scroll all the way to the bottom of bot.linespolice-cad.com → sidebar shows **Support** as active
- [ ] Scroll back up into FAQ → sidebar flips back to **FAQ**
- [ ] Resize the window with the page at bottom → still **Support** (no flicker back to FAQ)
- [ ] Footer shows the current year

🤖 Generated with [Claude Code](https://claude.com/claude-code)