### PR TITLE
fix(docs): scroll-spy works for tall sections (Commands) and short ones (Support)

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -41,38 +41,46 @@
     );
   };
 
+  // Scroll-spy: pick the section whose top has most-recently passed an
+  // "activation line" at 30% of viewport height. Reliable regardless of
+  // section size — IntersectionObserver-based versions broke on very tall
+  // sections (Commands) whose intersection ratio never crossed the lowest
+  // threshold, and on very short ones (Support) at the bottom edge.
+  const lastSectionId = sectionEls.length ? sectionEls[sectionEls.length - 1].id : null;
+
   const isNearBottom = () =>
     window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 8;
 
-  const lastSectionId = sectionEls.length ? sectionEls[sectionEls.length - 1].id : null;
-
-  if ("IntersectionObserver" in window) {
-    const obs = new IntersectionObserver(
-      (entries) => {
-        // When the page is scrolled to the bottom, the last section can sit
-        // below the observer's active band (rootMargin) and never be flagged
-        // as visible. Force it active in that case.
-        if (lastSectionId && isNearBottom()) {
-          setActive(lastSectionId);
-          return;
-        }
-        const visible = entries
-          .filter((e) => e.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
-        if (visible) setActive(visible.target.id);
-      },
-      { rootMargin: "-30% 0px -55% 0px", threshold: [0.1, 0.5, 0.9] }
-    );
-    sectionEls.forEach((el) => obs.observe(el));
-  }
-
-  // Scroll/resize fallback for the bottom edge — IntersectionObserver may not
-  // re-fire if you scroll the last few pixels into view.
-  const onScrollEdge = () => {
-    if (lastSectionId && isNearBottom()) setActive(lastSectionId);
+  const updateActiveSection = () => {
+    if (!sectionEls.length) return;
+    if (isNearBottom()) {
+      setActive(lastSectionId);
+      return;
+    }
+    const activationLine = window.innerHeight * 0.3;
+    let active = sectionEls[0];
+    for (const el of sectionEls) {
+      if (el.getBoundingClientRect().top <= activationLine) {
+        active = el;
+      } else {
+        break;
+      }
+    }
+    setActive(active.id);
   };
-  window.addEventListener("scroll", onScrollEdge, { passive: true });
-  window.addEventListener("resize", onScrollEdge);
+
+  let scrollScheduled = false;
+  const onScroll = () => {
+    if (scrollScheduled) return;
+    scrollScheduled = true;
+    requestAnimationFrame(() => {
+      updateActiveSection();
+      scrollScheduled = false;
+    });
+  };
+  window.addEventListener("scroll", onScroll, { passive: true });
+  window.addEventListener("resize", onScroll);
+  updateActiveSection();
 
   /* ---------- footer year ---------- */
   const yearEl = document.getElementById("copyright-year");


### PR DESCRIPTION
## Summary

PR #20 patched the bottom-edge case but exposed a deeper bug: the IntersectionObserver-based scroll-spy was silently broken on the **Commands** section the whole time.

### The bug

- Active band: \`rootMargin: -30% 0px -55%\` = a 15% × viewport-width strip ≈ 135px on a 900px viewport.
- Commands section height: ~2000px (22 cards + toolbar + header).
- Max possible \`intersectionRatio\` for Commands inside the band = 135 / 2000 ≈ **0.07**.
- Lowest configured threshold: **0.1**.
- → The observer never fires for Commands entering or leaving the band. Whatever was active before scrolling into Commands stayed active.

Once Support got activated at the bottom (working as intended after #20), scrolling back up through FAQ → Commands left "Support" highlighted forever.

### The fix

Dropped the IntersectionObserver. Replaced with a `getBoundingClientRect`-based scan: on every scroll (rAF-throttled) and resize, pick the last section whose top has crossed an activation line at 30% of the viewport. Works identically for a 200px-tall section and a 2000px-tall one. Bottom-edge fallback from #20 is kept (force last section when within 8px of page bottom).

35-line diff in `docs/assets/app.js`, no markup or CSS changes.

## Test plan

- [ ] Scroll down through the whole page on bot.linespolice-cad.com → sidebar tracks Home → Setup → Commands → FAQ → Support correctly
- [ ] Scroll back up from Support → sidebar tracks Support → FAQ → Commands → Setup → Home
- [ ] Stop mid-Commands (any position) → sidebar shows **Commands**
- [ ] Click each sidebar link → page jumps and that link highlights
- [ ] Mobile: hamburger nav still works, taps still close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)