### PR TITLE
fix(bot): name required roles in permission error + harden /roles view

### DIFF
--- a/commands/case.js
+++ b/commands/case.js
@@ -94,7 +94,7 @@ module.exports = {
       }
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command" });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID) });
 
       const user = await client.dbo.collection("users").findOne({ "user.discord.id": interaction.member.user.id });
       if (!user) return interaction.send({ content: `You are not logged in.` });

--- a/commands/check-status.js
+++ b/commands/check-status.js
@@ -31,7 +31,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.` });
 
       let useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content:  "You don't have permission to use this command" });
+      if (!useCommand) return interaction.send({ content:  await client.noPermissionMessage(GuildDB.serverID) });
       
       const user = await client.dbo.collection("users").findOne({ "user.discord.id": interaction.member.user.id }).then(user => user);
       if (!user)

--- a/commands/civilian.js
+++ b/commands/civilian.js
@@ -275,7 +275,7 @@ module.exports = {
       }
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command" });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID) });
 
       const user = await client.dbo.collection('users').findOne({ 'user.discord.id': interaction.member.user.id });
       if (!user) return interaction.send({ content: `You are not logged in.` });

--- a/commands/clock-in.js
+++ b/commands/clock-in.js
@@ -76,7 +76,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/clock-out.js
+++ b/commands/clock-out.js
@@ -22,7 +22,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/contest-fine.js
+++ b/commands/contest-fine.js
@@ -89,7 +89,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/inbox.js
+++ b/commands/inbox.js
@@ -78,7 +78,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/panic.js
+++ b/commands/panic.js
@@ -21,7 +21,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       let useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await client.dbo.collection("users").findOne({ "user.discord.id": interaction.member.user.id });
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/pay-fine.js
+++ b/commands/pay-fine.js
@@ -82,7 +82,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/roles.js
+++ b/commands/roles.js
@@ -64,18 +64,26 @@ module.exports = {
           return interaction.send({ content: 'There are no roles set for the bot.' });
         }
 
-        let roles = ``;
+        // Resolve role names, skipping any that were deleted from the server.
+        // A deleted role used to crash this command (role.name on undefined),
+        // which left admins unable to even see what was locking the bot.
+        let resolvedNames = [];
         for (let i = 0; i < guild.server.allowedRoles.length; i++) {
-          if (guild.server.allowedRoles[i] == undefined) break;
+          if (guild.server.allowedRoles[i] == undefined) continue;
           let role = interaction.guild.roles.cache.find(r => r.id == guild.server.allowedRoles[i]);
-          if (roles.length==0) roles += `@${role.name}`;
-          else roles += `\n@${role.name}`;
+          if (role) resolvedNames.push(`@${role.name}`);
         }
+
+        if (resolvedNames.length == 0) {
+          return interaction.send({ content: 'The allowed roles for the bot no longer exist (they were deleted). The restriction will clear automatically the next time a command is run, or you can run `/roles remove` to clear it now.' });
+        }
+
+        let roles = resolvedNames.join('\n');
         let rolesEmbed = new EmbedBuilder()
           .setColor('#0099ff')
           .setDescription('|**Allowed Roles to use the Bot**')
           .addFields(
-            { name: `There are currently **${guild.server.allowedRoles.length}** allowed roles.`, value: `\`${roles}\``, inline: true },
+            { name: `There are currently **${resolvedNames.length}** allowed roles.`, value: `\`${roles}\``, inline: true },
           )
           .setFooter({ text: 'LPS Website Support', iconURL: client.config.IconURL, proxyIconURL: 'https://discord.gg/jgUW656v2t' })
         return interaction.send({ embeds: [rolesEmbed] });

--- a/commands/search.js
+++ b/commands/search.js
@@ -99,7 +99,7 @@ module.exports = {
       }
       
       let useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.editOriginal({ content: "You don't have permission to use this command" });
+      if (!useCommand) return interaction.editOriginal({ content: await client.noPermissionMessage(GuildDB.serverID) });
 
       const user = await client.dbo.collection("users").findOne({"user.discord.id":interaction.member.user.id}).then(user => user);
       if (!user) return interaction.editOriginal({ content: `You are not logged in.` });

--- a/commands/send-money.js
+++ b/commands/send-money.js
@@ -135,7 +135,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/set-active-civilian.js
+++ b/commands/set-active-civilian.js
@@ -53,7 +53,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/set-active-community.js
+++ b/commands/set-active-community.js
@@ -50,7 +50,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/signal-100.js
+++ b/commands/signal-100.js
@@ -21,7 +21,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       let useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await client.dbo.collection("users").findOne({ "user.discord.id": interaction.member.user.id });
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/commands/update-license.js
+++ b/commands/update-license.js
@@ -179,7 +179,7 @@ module.exports = {
       }
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command" });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID) });
 
       const user = await client.dbo.collection('users').findOne({ 'user.discord.id': interaction.member.user.id });
       if (!user) return interaction.send({ content: `You are not logged in.` });

--- a/commands/update-status.js
+++ b/commands/update-status.js
@@ -39,7 +39,7 @@ module.exports = {
       }
 
       let useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command" });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID) });
 
       let user = await client.dbo.collection("users").findOne({"user.discord.id":interaction.member.user.id}).then(user => user);
       if (!user) return interaction.send({ content: `You are not logged in <@${interaction.member.user.id}>` });

--- a/commands/wallet.js
+++ b/commands/wallet.js
@@ -67,7 +67,7 @@ module.exports = {
         return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
 
       const useCommand = await client.verifyUseCommand(GuildDB.serverID, interaction.member.roles);
-      if (!useCommand) return interaction.send({ content: "You don't have permission to use this command", flags: (1 << 6) });
+      if (!useCommand) return interaction.send({ content: await client.noPermissionMessage(GuildDB.serverID), flags: (1 << 6) });
 
       const user = await getLpcUser(client, interaction.member.user.id);
       if (!user) return interaction.send({ content: `You are not logged in. Go to https://linespolice-cad.com/ to login, and connect your Discord account.`, flags: (1 << 6) });

--- a/docs/index.html
+++ b/docs/index.html
@@ -170,7 +170,8 @@
         <p>Once the bot is running, server admins can lock it down further:</p>
         <ul>
           <li><code class="kbd-inline">/channels set channel:#dispatch</code> — restrict the bot to a specific channel</li>
-          <li><code class="kbd-inline">/roles set role:@Officer</code> — gate commands behind a Discord role</li>
+          <li><code class="kbd-inline">/roles set role:@Officer</code> — gate commands behind a Discord role
+            <em>(this overrides Discord admin/owner status — only people with this role can use the bot, so make sure your staff have it; clear it anytime with <code class="kbd-inline">/roles remove</code>)</em></li>
           <li><code class="kbd-inline">/ping-on-panic toggle toggle:True role:@Dispatchers</code> — ping a role on panic / Signal 100</li>
         </ul>
         <p class="next-steps-foot">Each of these requires <em>Manage Server</em> on Discord.</p>
@@ -237,8 +238,27 @@
         <details>
           <summary>"You don't have permission to use this command."</summary>
           <p>
-            A server admin gated the bot behind specific Discord roles. Run
-            <code class="kbd-inline">/roles view</code> to see which roles are allowed.
+            The bot keeps its <strong>own</strong> allowed-roles list, set with
+            <code class="kbd-inline">/roles</code>. This is <em>separate from Discord's permissions</em> —
+            once any role is added, only members who have one of those roles can run commands.
+            Being a server <strong>admin or owner doesn't bypass it</strong>, and Discord's per-command
+            permission overrides won't change it either. That's usually why "I'm an admin and it still
+            blocks me" happens.
+          </p>
+          <p>
+            The bot now names the required role(s) right in the error. To fix it, anyone with
+            <strong>Manage Server</strong> should:
+          </p>
+          <ol>
+            <li>Run <code class="kbd-inline">/roles view</code> to see which role(s) are required.</li>
+            <li>Run <code class="kbd-inline">/roles remove role:@TheRole</code> for each one — removing the
+              <em>last</em> role turns the restriction off entirely and everyone can use the bot again.</li>
+            <li>Prefer to keep it restricted? Run <code class="kbd-inline">/roles set role:@YourStaffRole</code>
+              with a role your members actually have.</li>
+          </ol>
+          <p>
+            If the gating role was deleted from the server, the restriction clears automatically the next
+            time any command is run.
           </p>
         </details>
         <details>

--- a/structures/LinesPoliceCadBot.js
+++ b/structures/LinesPoliceCadBot.js
@@ -373,7 +373,7 @@ class LinesPoliceCadBot extends Client {
 
     // If some roles no longer exists, update
     // or if customRoleStatus is true but no roles exist, update
-    if (update || (filteredRoles.length == 0 && customRoleStatus)) {
+    if (update || (filteredRoles.length == 0 && guildDB.customRoleStatus)) {
       let newHasCustomRoles = filteredRoles.length > 0;
 
       await this.dbo.collection("prefixes").updateOne(
@@ -392,6 +392,44 @@ class LinesPoliceCadBot extends Client {
 
     let hasRole = await this.checkRoleStatus(rolesCache, filteredRoles);
     return hasRole;
+  }
+
+  /*
+   Builds the message shown when a user fails verifyUseCommand.
+   When the server has restricted the bot to specific roles, this names
+   those roles so the user knows exactly what they need, instead of a
+   blank "you don't have permission". Deleted roles are skipped. Falls
+   back to the generic message on any error or when no roles resolve.
+  */
+  async noPermissionMessage(serverID) {
+    const base = "You don't have permission to use this command.";
+    try {
+      const guildDB = await this.GetGuild(serverID);
+      if (
+        !guildDB ||
+        !guildDB.customRoleStatus ||
+        !Array.isArray(guildDB.allowedRoles) ||
+        guildDB.allowedRoles.length === 0
+      ) {
+        return base;
+      }
+
+      const guild = this.guilds.cache.get(serverID);
+      const names = [];
+      for (let i = 0; i < guildDB.allowedRoles.length; i++) {
+        const role = guild && guild.roles.cache.get(guildDB.allowedRoles[i]);
+        if (role) names.push(`@${role.name}`);
+      }
+      if (names.length === 0) return base;
+
+      return (
+        `${base}\n\nThis server limits the bot to members with: **${names.join(", ")}**.\n` +
+        "Ask a server admin to give you one of these roles, or have someone with " +
+        "**Manage Server** adjust it with `/roles`."
+      );
+    } catch (e) {
+      return base;
+    }
   }
 
   log(Text) {


### PR DESCRIPTION
## Problem

A server admin reported the bot kept saying **"You don't have permission to use this command"** — even though they were an admin, even after overriding Discord command permissions, and even owners couldn't fix it.

Root cause: the bot has its **own** allowed-roles list (set via `/roles`), stored in our DB and **completely separate from Discord's permission system**. Once any role is added, `verifyUseCommand` only allows members holding one of those roles — Discord admin/owner status and per-command overrides don't bypass it. The error gave **no hint** which role was needed or that it was even a bot setting, so admins had no way to self-diagnose.

Two things made it worse:
- `/roles view` **crashed** when an allowed role had since been deleted (`role.name` on `undefined`), so admins couldn't even see what was blocking them.
- A latent undefined-variable reference (`customRoleStatus` instead of `guildDB.customRoleStatus`) in the role-cleanup path.

## Changes

- **`structures/LinesPoliceCadBot.js`**: new `noPermissionMessage(serverID)` that builds a role-aware denial naming the required role(s) and pointing to `/roles`. Skips deleted roles; falls back to the generic message on any error. `verifyUseCommand` still returns a **boolean** — unchanged contract, so all 17 `if (!useCommand)` call sites behave exactly as before. Also fixed the `customRoleStatus` typo.
- **17 commands**: route the denial through the helper (no other logic changed; existing `send`/`editOriginal`/ephemeral-flag forms preserved).
- **`commands/roles.js`**: `/roles view` now skips deleted roles instead of crashing, counts only resolved roles, and shows a helpful message when every allowed role was deleted.
- **`docs/index.html`**: expanded the FAQ entry for this error with the full explanation + fix steps, and added a caution to the `/roles set` setup tip so admins don't lock themselves out.

## Notes

- `docs/commands.json` regenerated via `node scripts/build-docs.js` — no diff (denial text isn't command metadata), so docs-sync CI stays green.
- All modified JS files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)