### PR TITLE
fix(vehicles): read both flag encodings instead of only the numeric one

### DIFF
--- a/commands/civilian.js
+++ b/commands/civilian.js
@@ -49,8 +49,20 @@ function fmtDate(v) {
 }
 
 function yesNo(b) { return b ? 'Yes' : 'No'; }
+
+/*
+ * Vehicle flags come in two encodings. Newer records use "true"/"false"; older
+ * ones use a 1-based select index from the original form, whose polarity is
+ * per-field — "1" = valid registration, but "2" = stolen. Roughly 92% of
+ * vehicles still carry the numeric form, and ~5% the modern one, so both
+ * branches matter. See police-cad/public/js/vehicle-flags.js.
+ */
 function stolenYes(v) { return v === 'true' || v === '2' || v === true; }
-function regLabel(v) { return v === '1' ? 'Valid' : v === '2' ? 'Invalid' : '—'; }
+function regValid(v) { return v === '1' || v === 'true' || v === true; }
+function regLabel(v) {
+  if (v === undefined || v === null || v === '') return '—';
+  return regValid(v) ? 'Valid' : 'Invalid';
+}
 
 function capNote(items, rendered) {
   return items.length > rendered.length

--- a/commands/search.js
+++ b/commands/search.js
@@ -170,15 +170,21 @@ module.exports = {
             { name: `**Owner**`, value: `\`${owner}\``, inline: true },
           )
           // Other details
+          // Two encodings: newer records use "true"/"false", older ones a
+          // 1-based select index whose polarity is per-field ("1" = valid
+          // registration, but "2" = stolen). Only matching the numeric form
+          // dropped these fields entirely for the ~5% on the modern one.
+          // See police-cad/public/js/vehicle-flags.js.
+          const isSet = (v) => v !== undefined && v !== null && v !== '';
+          const yesIsOne = (v) => v === '1' || v === 'true' || v === true;
+          const yesIsTwo = (v) => v === '2' || v === 'true' || v === true;
+
           let validRegistration = results.vehicle.validRegistration;
           let validInsurance = results.vehicle.validInsurance;
           let stolen = results.vehicle.isStolen;
-          if (validRegistration=='1') plateResult.addFields({ name: `**Registration**`, value: `\`Valid\``, inline: true });
-          if (validRegistration=='2') plateResult.addFields({ name: `**Registration**`, value: `\`InValid\``, inline: true });
-          if (validInsurance=='1') plateResult.addFields({ name: `**Insurance**`, value: `\`Valid\``, inline: true });
-          if (validInsurance=='2') plateResult.addFields({ name: `**Insurance**`, value: `\`InValid\``, inline: true });
-          if (stolen=='1') plateResult.addFields({ name: `**Stolen**`, value: `\`No\``, inline: true });
-          if (stolen=='2') plateResult.addFields({ name: `**Stolen**`, value: `\`Yes\``, inline: true });
+          if (isSet(validRegistration)) plateResult.addFields({ name: `**Registration**`, value: `\`${yesIsOne(validRegistration) ? 'Valid' : 'InValid'}\``, inline: true });
+          if (isSet(validInsurance)) plateResult.addFields({ name: `**Insurance**`, value: `\`${yesIsOne(validInsurance) ? 'Valid' : 'InValid'}\``, inline: true });
+          if (isSet(stolen)) plateResult.addFields({ name: `**Stolen**`, value: `\`${yesIsTwo(stolen) ? 'Yes' : 'No'}\``, inline: true });
 
           return interaction.editOriginal({ embeds: [plateResult] });
         });


### PR DESCRIPTION
## Why

Vehicle flags are stored in two encodings — newer records use `"true"`/`"false"`, older ones a 1-based select index from the original form. The bot was the **only** surface that understood just the numeric one:

- `regLabel()` returned `—` for `"true"`/`"false"`, so Registration and Insurance showed as an em dash on ~5% of vehicles (121k records).
- `/search plate` only added the Registration, Insurance and Stolen fields when the value was `"1"` or `"2"` — so for those same records the fields were **silently absent from the embed entirely**.

Both now accept either encoding, keeping the per-field polarity: `"1"` is a valid registration, but `"2"` is stolen. (The numeric form is a select index, not a boolean, so its polarity follows the old form's option order — `Yes,No` for registration but `No,Yes` for stolen.)

## Deploy ordering

⚠️ **This needs to land before or with [police-cad-api#179](https://github.com/Linesmerrill/police-cad-api/pull/179)**, which normalizes flags on read. The moment the API starts emitting `"true"`/`"false"`, a numeric-only reader breaks — and this was the last one. Every other surface already accepts both.

## Notes

No command metadata changed, so `docs/commands.json` regenerates byte-identically — `docs-sync` CI will pass. Confirmed by re-running `node scripts/build-docs.js` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
