### PR TITLE
refactor(search): move plate lookup onto the API, add autocomplete, and show what it was hiding

### DIFF
--- a/commands/civilian.js
+++ b/commands/civilian.js
@@ -190,8 +190,14 @@ async function buildHubPayload(client, civilianId, activeKey) {
   const embed = new EmbedBuilder()
     .setColor(ACCENT)
     .setAuthor({ name: `${tab.emoji} ${tab.label}`, iconURL: client.config.IconURL })
-    .setTitle(displayName)
-    .setFooter({ text: `ID: ${civilianId}` });
+    .setTitle(displayName);
+
+  // Footer carries the DOB rather than the record id — nobody can act on a raw
+  // ObjectId, whereas DOB is what actually tells two same-named civilians
+  // apart. It matters here specifically because DOB is a field on the overview
+  // tab only; every other tab replaces the fields with a body, so without this
+  // the name is the sole identifier once you switch sections.
+  if (c.birthday) embed.setFooter({ text: `DOB: ${c.birthday}` });
   if (c.image) embed.setThumbnail(c.image);
 
   if (tab.key === 'overview') {
@@ -319,6 +325,11 @@ module.exports = {
       }
     },
   },
+  // Exported so other commands can open this same record view rather than
+  // rendering their own thinner version of it — /search plate's owner button
+  // uses it. Functions are dropped when the command object is serialized for
+  // Discord's registration payload, so this is invisible to the API.
+  buildHubPayload,
   Interactions: {
     // Tab select → render the chosen section.
     civtab: {

--- a/commands/search.js
+++ b/commands/search.js
@@ -4,7 +4,13 @@ const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const ObjectId = require("mongodb").ObjectId;
 const { getLpcUser, getFocusedOption, civilianName } = require('../util/economy');
 const { civilianAutocompleteChoices, resolveCivilian } = require('../util/civilians');
-const { plateAutocompleteChoices, resolveVehicle, vehicleName } = require('../util/vehicles');
+const {
+  plateAutocompleteChoices,
+  resolveVehicle,
+  vehicleName,
+  communityVehicleCount,
+} = require('../util/vehicles');
+const { getCommunityName } = require('../util/communities');
 const { apiRequest } = require('../util/api');
 const {
   getCivilianLicenses,
@@ -155,16 +161,35 @@ module.exports = {
         // The autocomplete picker submits the vehicle's _id; a free-typed plate
         // falls back to the best server-side match. Both go through the API
         // rather than reading Mongo directly.
+        //
+        // The community name is fetched alongside so it costs no extra wait.
+        // Every search is scoped to the active community, which is easy to
+        // forget you're in — naming it means a genuine miss doesn't look the
+        // same as searching the wrong community.
         let results = null;
+        let communityLabel = null;
         try {
-          results = await resolveVehicle(client, communityId, typed);
+          [results, communityLabel] = await Promise.all([
+            resolveVehicle(client, communityId, typed),
+            getCommunityName(client, communityId),
+          ]);
         } catch (err) {
           client.error(`/search plate: ${err.message}`);
           return interaction.editOriginal({ content: `Something went wrong looking up that plate. Try again in a moment.` });
         }
 
+        const inCommunity = communityLabel ? ` in **${communityLabel}**` : '';
+
         if (!results || !results.vehicle) {
-          return interaction.editOriginal({ content: `Plate Number \`${typed}\` not found.` });
+          const fleet = await communityVehicleCount(client, communityId);
+          const where = communityLabel ? 'that community' : 'your active community';
+          const searched = fleet === null
+            ? `\n_Searches only cover ${where}. If the vehicle is registered elsewhere, switch communities on the website._`
+            : `\n_Searched all ${fleet.toLocaleString()} ${fleet === 1 ? 'vehicle' : 'vehicles'} in ${where}.`
+              + ` If it's registered elsewhere, switch communities on the website._`;
+          return interaction.editOriginal({
+            content: `Plate Number \`${typed}\` not found${inCommunity}.${searched}`,
+          });
         }
 
         const d = results.vehicle;
@@ -205,7 +230,9 @@ module.exports = {
         .setColor(stolen ? '#ef4444' : (alerts.length ? '#f59e0b' : '#38bdf8'))
         .setAuthor({ name: 'Plate Search', iconURL: client.config.IconURL })
         .setTitle(`${d.plate || '—'}${name ? ` · ${name}` : ''}`)
-        .setFooter({ text: `ID: ${results._id}` });
+        // Name the community here too, so a result from the wrong one is
+        // spottable without having to notice the absence of the right one.
+        .setFooter({ text: communityLabel ? `${communityLabel} · ID: ${results._id}` : `ID: ${results._id}` });
 
         if (alerts.length) plateResult.setDescription(alerts.join('\n'));
         if (d.image) plateResult.setThumbnail(d.image);

--- a/commands/search.js
+++ b/commands/search.js
@@ -116,7 +116,7 @@ module.exports = {
 
       const user = await client.dbo.collection("users").findOne({"user.discord.id":interaction.member.user.id}).then(user => user);
       if (!user) return interaction.editOriginal({ content: `You are not logged in.` });
-      if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) return interaction.editOriginal({ content: `You are not in an active community.` });
+      if (!user.user.lastAccessedCommunity || !user.user.lastAccessedCommunity.communityID) return interaction.editOriginal({ content: `You are not in an active community. Run \`/set-active-community\` to pick one.` });
 
       if (args[0].name == "firearm") {
         let query = {
@@ -183,10 +183,11 @@ module.exports = {
         if (!results || !results.vehicle) {
           const fleet = await communityVehicleCount(client, communityId);
           const where = communityLabel ? 'that community' : 'your active community';
+          // Point at the bot command, not the website — they can switch right here.
+          const elsewhere = ` If it's registered elsewhere, run \`/set-active-community\` to switch._`;
           const searched = fleet === null
-            ? `\n_Searches only cover ${where}. If the vehicle is registered elsewhere, switch communities on the website._`
-            : `\n_Searched all ${fleet.toLocaleString()} ${fleet === 1 ? 'vehicle' : 'vehicles'} in ${where}.`
-              + ` If it's registered elsewhere, switch communities on the website._`;
+            ? `\n_Searches only cover ${where}.${elsewhere}`
+            : `\n_Searched all ${fleet.toLocaleString()} ${fleet === 1 ? 'vehicle' : 'vehicles'} in ${where}.${elsewhere}`;
           return interaction.editOriginal({
             content: `Plate Number \`${typed}\` not found${inCommunity}.${searched}`,
           });

--- a/commands/search.js
+++ b/commands/search.js
@@ -1,4 +1,9 @@
-const { EmbedBuilder } = require('discord.js');
+const {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require('discord.js');
 const io = require('socket.io-client');
 const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const ObjectId = require("mongodb").ObjectId;
@@ -12,6 +17,8 @@ const {
 } = require('../util/vehicles');
 const { getCommunityName, communityUrl } = require('../util/communities');
 const { apiRequest } = require('../util/api');
+// Reuse /civilian's record renderer rather than building a thinner copy here.
+const { buildHubPayload: buildCivilianHub } = require('./civilian');
 const {
   getCivilianLicenses,
   pickLicense,
@@ -138,7 +145,6 @@ module.exports = {
             .setColor('#38bdf8')
             .setAuthor({ name: 'Firearm Search', iconURL: client.config.IconURL })
             .setTitle(`${results.firearm.serialNumber}`)
-            .setFooter({ text: `ID: ${results._id}` })
             .addFields(
               { name: `**Serial Number**`, value: `\`${results.firearm.serialNumber}\``, inline: true },
               { name: `**Name**`, value: `\`${results.firearm.name}\``, inline: true },
@@ -196,10 +202,14 @@ module.exports = {
         const d = results.vehicle;
 
         let owner = "N/A";
+        let ownerId = null;
         if (d.linkedCivilianID) {
           try {
             const civ = await apiRequest(client, 'GET', `/api/v1/civilian/${d.linkedCivilianID}`);
-            if (civ && civ.civilian && civ.civilian.name) owner = civ.civilian.name;
+            if (civ && civ.civilian && civ.civilian.name) {
+              owner = civ.civilian.name;
+              ownerId = String(civ._id || d.linkedCivilianID);
+            }
           } catch (err) {
             // An unreachable owner shouldn't blank the whole lookup.
             client.error(`/search plate owner ${d.linkedCivilianID}: ${err.message}`);
@@ -275,7 +285,21 @@ module.exports = {
           });
         }
 
-        return interaction.editOriginal({ embeds: [plateResult] });
+        // Discord can't pre-fill and submit a slash command for someone, but a
+        // button can just do the lookup — one click instead of retyping the
+        // owner's name into /civilian and hoping the autocomplete matches.
+        const rows = [];
+        if (ownerId) {
+          rows.push(new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+              .setCustomId(`plateowner-${ownerId}`)
+              .setLabel(`View owner: ${owner}`.slice(0, 80))
+              .setStyle(ButtonStyle.Primary)
+              .setEmoji('👤')
+          ));
+        }
+
+        return interaction.editOriginal({ embeds: [plateResult], components: rows });
 
       } else if (args[0].name == "name") {
         const communityId = user.user.lastAccessedCommunity.communityID;
@@ -328,7 +352,7 @@ module.exports = {
             { name: '🪪 Drivers License', value: `\`${licenceStatus}\``, inline: true },
             { name: '🔫 Firearm License', value: `\`${firearmLicence}\``, inline: true },
           )
-          .setFooter({ text: `ID: ${results._id} · Tip: /civilian shows the full record` });
+          .setFooter({ text: `Tip: /civilian shows the full record` });
         if (results.civilian.image) nameResult.setThumbnail(results.civilian.image);
 
         // Optional details
@@ -361,6 +385,48 @@ module.exports = {
         );
         return interaction.editOriginal({ embeds: [nameResult] });
       }
+    },
+  },
+  Interactions: {
+    // "View owner" on a plate result. Opens the same record view /civilian
+    // renders, in a new ephemeral message so the plate embed stays put — the
+    // tab select on it works because /civilian registers that handler globally.
+    plateowner: {
+      run: async (client, interaction) => {
+        try {
+          const civilianId = interaction.customId.split('-')[1];
+          if (!civilianId) return;
+
+          // Re-check scope rather than trusting the customId. The button only
+          // ever appears on an ephemeral result the clicker owns, but a
+          // customId is just a string a client can send.
+          const user = await getLpcUser(client, interaction.user.id);
+          const communityId = user && user.user && user.user.lastAccessedCommunity
+            && user.user.lastAccessedCommunity.communityID;
+          if (!communityId) {
+            return interaction.reply({
+              content: 'You are not in an active community. Run `/set-active-community` to pick one.',
+              flags: (1 << 6),
+            });
+          }
+
+          const civ = await resolveCivilian(client, communityId, civilianId);
+          if (!civ) {
+            return interaction.reply({
+              content: 'That civilian is no longer available in your active community.',
+              flags: (1 << 6),
+            });
+          }
+
+          const payload = await buildCivilianHub(client, String(civ._id), 'overview');
+          return interaction.reply({ ...payload, flags: (1 << 6) });
+        } catch (err) {
+          client.error(`plateowner: ${err.message}`);
+          try {
+            return interaction.reply({ content: 'Failed to load that owner.', flags: (1 << 6) });
+          } catch (_) {}
+        }
+      },
     },
   },
 }

--- a/commands/search.js
+++ b/commands/search.js
@@ -169,22 +169,30 @@ module.exports = {
             { name: `**Color**`, value: `\`${results.vehicle.color}\``, inline: true },
             { name: `**Owner**`, value: `\`${owner}\``, inline: true },
           )
-          // Other details
+          // Other details.
+          //
           // Two encodings: newer records use "true"/"false", older ones a
           // 1-based select index whose polarity is per-field ("1" = valid
-          // registration, but "2" = stolen). Only matching the numeric form
-          // dropped these fields entirely for the ~5% on the modern one.
-          // See police-cad/public/js/vehicle-flags.js.
-          const isSet = (v) => v !== undefined && v !== null && v !== '';
+          // registration, but "2" = stolen). This command reads Mongo directly
+          // rather than through the API, so it sees the raw stored value and
+          // has to resolve both itself.
+          // See police-cad/public/js/vehicle-flags.js for the full explanation.
+          //
+          // These fields render unconditionally. Skipping an absent or empty
+          // value left an officer with no Stolen line at all, which reads as
+          // "unknown" when every other surface would say "No" -- the API
+          // resolves a missing flag to false, so match that.
           const yesIsOne = (v) => v === '1' || v === 'true' || v === true;
           const yesIsTwo = (v) => v === '2' || v === 'true' || v === true;
 
           let validRegistration = results.vehicle.validRegistration;
           let validInsurance = results.vehicle.validInsurance;
           let stolen = results.vehicle.isStolen;
-          if (isSet(validRegistration)) plateResult.addFields({ name: `**Registration**`, value: `\`${yesIsOne(validRegistration) ? 'Valid' : 'InValid'}\``, inline: true });
-          if (isSet(validInsurance)) plateResult.addFields({ name: `**Insurance**`, value: `\`${yesIsOne(validInsurance) ? 'Valid' : 'InValid'}\``, inline: true });
-          if (isSet(stolen)) plateResult.addFields({ name: `**Stolen**`, value: `\`${yesIsTwo(stolen) ? 'Yes' : 'No'}\``, inline: true });
+          let exempt = results.vehicle.isExempt;
+          plateResult.addFields({ name: `**Registration**`, value: `\`${yesIsOne(validRegistration) ? 'Valid' : 'InValid'}\``, inline: true });
+          plateResult.addFields({ name: `**Insurance**`, value: `\`${yesIsOne(validInsurance) ? 'Valid' : 'InValid'}\``, inline: true });
+          plateResult.addFields({ name: `**Stolen**`, value: `\`${yesIsTwo(stolen) ? 'Yes' : 'No'}\``, inline: true });
+          if (yesIsOne(exempt)) plateResult.addFields({ name: `**Exempt**`, value: `\`Yes\``, inline: true });
 
           return interaction.editOriginal({ embeds: [plateResult] });
         });

--- a/commands/search.js
+++ b/commands/search.js
@@ -10,7 +10,7 @@ const {
   vehicleName,
   communityVehicleCount,
 } = require('../util/vehicles');
-const { getCommunityName } = require('../util/communities');
+const { getCommunityName, communityUrl } = require('../util/communities');
 const { apiRequest } = require('../util/api');
 const {
   getCivilianLicenses,
@@ -220,20 +220,22 @@ module.exports = {
         const name = vehicleName(results);
         const dash = (v) => (v === undefined || v === null || v === '' ? '—' : v);
 
-        // Lead with the flags an officer is actually looking for.
+        const regOk = yesIsOne(d.validRegistration);
+        const insOk = yesIsOne(d.validInsurance);
+
+        // Lead with the flags an officer is actually looking for. Same icons as
+        // the status fields below, so the summary and the detail agree at a
+        // glance rather than using two vocabularies for one fact.
         const alerts = [];
         if (stolen) alerts.push('🚨 **STOLEN**');
-        if (!yesIsOne(d.validRegistration)) alerts.push('⚠️ Invalid registration');
-        if (!yesIsOne(d.validInsurance)) alerts.push('⚠️ No insurance');
+        if (!regOk) alerts.push('❌ Invalid registration');
+        if (!insOk) alerts.push('❌ No insurance');
         if (exempt) alerts.push('🛡️ Exempt');
 
         let plateResult = new EmbedBuilder()
         .setColor(stolen ? '#ef4444' : (alerts.length ? '#f59e0b' : '#38bdf8'))
         .setAuthor({ name: 'Plate Search', iconURL: client.config.IconURL })
-        .setTitle(`${d.plate || '—'}${name ? ` · ${name}` : ''}`)
-        // Name the community here too, so a result from the wrong one is
-        // spottable without having to notice the absence of the right one.
-        .setFooter({ text: communityLabel ? `${communityLabel} · ID: ${results._id}` : `ID: ${results._id}` });
+        .setTitle(`${d.plate || '—'}${name ? ` · ${name}` : ''}`);
 
         if (alerts.length) plateResult.setDescription(alerts.join('\n'));
         if (d.image) plateResult.setThumbnail(d.image);
@@ -248,12 +250,30 @@ module.exports = {
           { name: `**Type**`, value: `\`${dash(d.type)}\``, inline: true },
           { name: `**Color**`, value: `\`${dash(d.color)}\``, inline: true },
           { name: `**Owner**`, value: `\`${owner}\``, inline: true },
-          // Rendered unconditionally: an omitted Stolen line reads as "unknown"
-          // when every other surface would say "No".
-          { name: `**Registration**`, value: `\`${yesIsOne(d.validRegistration) ? 'Valid' : 'Invalid'}\``, inline: true },
-          { name: `**Insurance**`, value: `\`${yesIsOne(d.validInsurance) ? 'Valid' : 'Invalid'}\``, inline: true },
-          { name: `**Stolen**`, value: `\`${stolen ? 'Yes' : 'No'}\``, inline: true },
+          // Status fields drop the code formatting the factual fields use, and
+          // carry an icon instead — these are the three an officer scans for,
+          // and monospace made them read like just more data. Note the icon
+          // tracks *good vs bad*, not the literal value: a stolen "Yes" is the
+          // alarming one, where an invalid registration is the "Invalid".
+          // Rendered unconditionally — an omitted Stolen line reads as
+          // "unknown" when every other surface would say "No".
+          { name: `**Registration**`, value: regOk ? '✅ Valid' : '❌ Invalid', inline: true },
+          { name: `**Insurance**`, value: insOk ? '✅ Valid' : '❌ Invalid', inline: true },
+          { name: `**Stolen**`, value: stolen ? '🚨 Yes' : '✅ No', inline: true },
         );
+
+        // Which community this came from, as a link straight to it. This lives
+        // in a full-width field rather than the footer because Discord renders
+        // footers as plain text — a markdown link there would show as literal
+        // brackets. Dropping the record id: nobody can do anything with it.
+        if (communityLabel) {
+          const url = communityUrl(communityId);
+          plateResult.addFields({
+            name: `**Community**`,
+            value: url ? `[${communityLabel}](${url})` : communityLabel,
+            inline: false,
+          });
+        }
 
         return interaction.editOriginal({ embeds: [plateResult] });
 

--- a/commands/search.js
+++ b/commands/search.js
@@ -4,6 +4,8 @@ const CommandOptions = require('../util/CommandOptionTypes').CommandOptionTypes;
 const ObjectId = require("mongodb").ObjectId;
 const { getLpcUser, getFocusedOption, civilianName } = require('../util/economy');
 const { civilianAutocompleteChoices, resolveCivilian } = require('../util/civilians');
+const { plateAutocompleteChoices, resolveVehicle, vehicleName } = require('../util/vehicles');
+const { apiRequest } = require('../util/api');
 const {
   getCivilianLicenses,
   pickLicense,
@@ -42,10 +44,11 @@ module.exports = {
       type: CommandOptions.SubCommand,
       options: [{
         name: "plate_number",
-        description: "Vehicle license plate number",
+        description: "Start typing a plate, then pick from the list",
         value: "plate_number",
         type: CommandOptions.String,
         required: true,
+        autocomplete: true,
       }],
     },
     {
@@ -66,14 +69,18 @@ module.exports = {
   Autocomplete: {
     run: async (client, interaction) => {
       const focused = getFocusedOption(interaction.data.options);
-      if (!focused || focused.name !== 'full_name') return interaction.respond([]);
+      if (!focused || (focused.name !== 'full_name' && focused.name !== 'plate_number')) {
+        return interaction.respond([]);
+      }
       try {
         const user = await getLpcUser(client, interaction.member.user.id);
         const communityId = user && user.user && user.user.lastAccessedCommunity
           && user.user.lastAccessedCommunity.communityID;
         if (!communityId) return interaction.respond([]);
 
-        const choices = await civilianAutocompleteChoices(client, communityId, focused.value);
+        const choices = focused.name === 'plate_number'
+          ? await plateAutocompleteChoices(client, communityId, focused.value)
+          : await civilianAutocompleteChoices(client, communityId, focused.value);
         return interaction.respond(choices);
       } catch (err) {
         client.error(`/search autocomplete: ${err.message}`);
@@ -142,60 +149,85 @@ module.exports = {
 
 
       } else if (args[0].name == "plate") {
-        let query = {
-          "vehicle.plate": args[0].options[0].value,
-          "vehicle.activeCommunityID": user.user.lastAccessedCommunity.communityID
-        };
+        const communityId = user.user.lastAccessedCommunity.communityID;
+        const typed = args[0].options[0].value;
 
-        client.dbo.collection("vehicles").findOne(query).then(async (results) => {
-          
-          if (!results) {
-            return interaction.editOriginal({ content: `Plate Number \`${args[0].options[0].value}\` not found.` });
+        // The autocomplete picker submits the vehicle's _id; a free-typed plate
+        // falls back to the best server-side match. Both go through the API
+        // rather than reading Mongo directly.
+        let results = null;
+        try {
+          results = await resolveVehicle(client, communityId, typed);
+        } catch (err) {
+          client.error(`/search plate: ${err.message}`);
+          return interaction.editOriginal({ content: `Something went wrong looking up that plate. Try again in a moment.` });
+        }
+
+        if (!results || !results.vehicle) {
+          return interaction.editOriginal({ content: `Plate Number \`${typed}\` not found.` });
+        }
+
+        const d = results.vehicle;
+
+        let owner = "N/A";
+        if (d.linkedCivilianID) {
+          try {
+            const civ = await apiRequest(client, 'GET', `/api/v1/civilian/${d.linkedCivilianID}`);
+            if (civ && civ.civilian && civ.civilian.name) owner = civ.civilian.name;
+          } catch (err) {
+            // An unreachable owner shouldn't blank the whole lookup.
+            client.error(`/search plate owner ${d.linkedCivilianID}: ${err.message}`);
           }
+        }
 
-          let civilian = null;
-          if (results.vehicle.linkedCivilianID != "") civilian = await client.dbo.collection("civilians").findOne({ _id: new ObjectId(results.vehicle.linkedCivilianID) }).then((civ) => civ);
-          let owner = civilian ? civilian.civilian.name : "N/A";
+        // Vehicle flags come in two encodings. Newer records use "true"/"false",
+        // older ones a 1-based select index whose polarity is per-field ("1" is
+        // a valid registration, but "2" is stolen). The API normalizes these on
+        // read, so this is belt-and-braces for a stale API deploy — it can go
+        // once every record has been backfilled.
+        // See police-cad/public/js/vehicle-flags.js for the full explanation.
+        const yesIsOne = (v) => v === '1' || v === 'true' || v === true;
+        const yesIsTwo = (v) => v === '2' || v === 'true' || v === true;
 
-          let plateResult = new EmbedBuilder()
-          .setColor('#38bdf8')
-          .setAuthor({ name: 'Plate Search', iconURL: client.config.IconURL })
-          .setTitle(`${results.vehicle.plate}`)
-          .setFooter({ text: `ID: ${results._id}` })
-          .addFields(
-            { name: `**Plate #**`, value: `\`${results.vehicle.plate}\``, inline: true },
-            { name: `**Vin #**`, value: `\`${results.vehicle.vin}\``, inline: true },
-            { name: `**Model**`, value: `\`${results.vehicle.model}\``, inline: true },
-            { name: `**Color**`, value: `\`${results.vehicle.color}\``, inline: true },
-            { name: `**Owner**`, value: `\`${owner}\``, inline: true },
-          )
-          // Other details.
-          //
-          // Two encodings: newer records use "true"/"false", older ones a
-          // 1-based select index whose polarity is per-field ("1" = valid
-          // registration, but "2" = stolen). This command reads Mongo directly
-          // rather than through the API, so it sees the raw stored value and
-          // has to resolve both itself.
-          // See police-cad/public/js/vehicle-flags.js for the full explanation.
-          //
-          // These fields render unconditionally. Skipping an absent or empty
-          // value left an officer with no Stolen line at all, which reads as
-          // "unknown" when every other surface would say "No" -- the API
-          // resolves a missing flag to false, so match that.
-          const yesIsOne = (v) => v === '1' || v === 'true' || v === true;
-          const yesIsTwo = (v) => v === '2' || v === 'true' || v === true;
+        const stolen = yesIsTwo(d.isStolen);
+        const exempt = yesIsOne(d.isExempt);
+        const name = vehicleName(results);
+        const dash = (v) => (v === undefined || v === null || v === '' ? '—' : v);
 
-          let validRegistration = results.vehicle.validRegistration;
-          let validInsurance = results.vehicle.validInsurance;
-          let stolen = results.vehicle.isStolen;
-          let exempt = results.vehicle.isExempt;
-          plateResult.addFields({ name: `**Registration**`, value: `\`${yesIsOne(validRegistration) ? 'Valid' : 'InValid'}\``, inline: true });
-          plateResult.addFields({ name: `**Insurance**`, value: `\`${yesIsOne(validInsurance) ? 'Valid' : 'InValid'}\``, inline: true });
-          plateResult.addFields({ name: `**Stolen**`, value: `\`${yesIsTwo(stolen) ? 'Yes' : 'No'}\``, inline: true });
-          if (yesIsOne(exempt)) plateResult.addFields({ name: `**Exempt**`, value: `\`Yes\``, inline: true });
+        // Lead with the flags an officer is actually looking for.
+        const alerts = [];
+        if (stolen) alerts.push('🚨 **STOLEN**');
+        if (!yesIsOne(d.validRegistration)) alerts.push('⚠️ Invalid registration');
+        if (!yesIsOne(d.validInsurance)) alerts.push('⚠️ No insurance');
+        if (exempt) alerts.push('🛡️ Exempt');
 
-          return interaction.editOriginal({ embeds: [plateResult] });
-        });
+        let plateResult = new EmbedBuilder()
+        .setColor(stolen ? '#ef4444' : (alerts.length ? '#f59e0b' : '#38bdf8'))
+        .setAuthor({ name: 'Plate Search', iconURL: client.config.IconURL })
+        .setTitle(`${d.plate || '—'}${name ? ` · ${name}` : ''}`)
+        .setFooter({ text: `ID: ${results._id}` });
+
+        if (alerts.length) plateResult.setDescription(alerts.join('\n'));
+        if (d.image) plateResult.setThumbnail(d.image);
+
+        plateResult.addFields(
+          { name: `**Plate #**`, value: `\`${dash(d.plate)}\``, inline: true },
+          { name: `**Plate State**`, value: `\`${dash(d.licensePlateState)}\``, inline: true },
+          { name: `**Vin #**`, value: `\`${dash(d.vin)}\``, inline: true },
+          { name: `**Make**`, value: `\`${dash(d.make)}\``, inline: true },
+          { name: `**Model**`, value: `\`${dash(d.model)}\``, inline: true },
+          { name: `**Year**`, value: `\`${dash(d.year)}\``, inline: true },
+          { name: `**Type**`, value: `\`${dash(d.type)}\``, inline: true },
+          { name: `**Color**`, value: `\`${dash(d.color)}\``, inline: true },
+          { name: `**Owner**`, value: `\`${owner}\``, inline: true },
+          // Rendered unconditionally: an omitted Stolen line reads as "unknown"
+          // when every other surface would say "No".
+          { name: `**Registration**`, value: `\`${yesIsOne(d.validRegistration) ? 'Valid' : 'Invalid'}\``, inline: true },
+          { name: `**Insurance**`, value: `\`${yesIsOne(d.validInsurance) ? 'Valid' : 'Invalid'}\``, inline: true },
+          { name: `**Stolen**`, value: `\`${stolen ? 'Yes' : 'No'}\``, inline: true },
+        );
+
+        return interaction.editOriginal({ embeds: [plateResult] });
 
       } else if (args[0].name == "name") {
         const communityId = user.user.lastAccessedCommunity.communityID;

--- a/commands/set-active-community.js
+++ b/commands/set-active-community.js
@@ -10,7 +10,7 @@ const {
 
 module.exports = {
   name: "set-active-community",
-  description: "Switch which community is active for /wallet, /inbox, /clock-in, /community view, etc.",
+  description: "Switch which community is active for /search, /wallet, /inbox, /clock-in, and more.",
   permissions: {
     channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
     member: [],

--- a/config/config.js
+++ b/config/config.js
@@ -12,7 +12,10 @@ module.exports = {
   IconURL: "https://raw.githubusercontent.com/Linesmerrill/police-cad/master/lines-police-cad.png",
   EmbedColor: "#0099ff",
   Permissions: 2205281600,
-  Website: "https://linespolice-cad.com",
+  // www, not the apex: the apex redirects to https://www.linespolice-cad.com
+  // WITHOUT the path, so anything built on top of this that isn't the bare
+  // homepage would land the user on the homepage instead.
+  Website: "https://www.linespolice-cad.com",
   api_url: process.env.API_URL || "",
   api_token: process.env.API_TOKEN || "",
   mongoURI: process.env.mongoURI || "mongodb://localhost:27017",

--- a/docs/commands.json
+++ b/docs/commands.json
@@ -556,7 +556,7 @@
           "options": [
             {
               "name": "plate_number",
-              "description": "Vehicle license plate number",
+              "description": "Start typing a plate, then pick from the list",
               "type": "String",
               "required": true
             }

--- a/docs/commands.json
+++ b/docs/commands.json
@@ -644,7 +644,7 @@
     },
     {
       "name": "set-active-community",
-      "description": "Switch which community is active for /wallet, /inbox, /clock-in, /community view, etc.",
+      "description": "Switch which community is active for /search, /wallet, /inbox, /clock-in, and more.",
       "category": "Community",
       "usage": null,
       "debug": false,

--- a/util/communities.js
+++ b/util/communities.js
@@ -16,6 +16,31 @@ const { apiRequest } = require('./api');
 const nameCache = new Map();
 
 /**
+ * The website addresses a community by a base64url-encoded id, not the raw one:
+ * `/community/:hash`, decoded by decodeId() in police-cad/app/routes.js. Keep
+ * this in step with encodeId() there — base64, then +/ swapped for -_ and the
+ * padding stripped.
+ */
+function encodeCommunityId(communityId) {
+  return Buffer.from(String(communityId), 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+// Must be the www host. The apex redirects with `Location:
+// https://www.linespolice-cad.com` and no path, so any deep link built on the
+// apex silently drops its path and dumps the user on the homepage.
+const SITE = 'https://www.linespolice-cad.com';
+
+/** Public URL for a community's page, or null if there's no id. */
+function communityUrl(communityId) {
+  if (!communityId) return null;
+  return `${SITE}/community/${encodeCommunityId(communityId)}`;
+}
+
+/**
  * Display name for a community, or null if it can't be resolved. Never throws —
  * a missing name should degrade the footer, not fail the command.
  */
@@ -35,4 +60,4 @@ async function getCommunityName(client, communityId) {
   return name;
 }
 
-module.exports = { getCommunityName };
+module.exports = { getCommunityName, communityUrl, encodeCommunityId };

--- a/util/communities.js
+++ b/util/communities.js
@@ -1,0 +1,38 @@
+/**
+ * Community lookup helpers.
+ *
+ * Commands scope everything to the user's active community, which is easy to
+ * forget you're in — a search that legitimately finds nothing looks identical
+ * to searching the wrong community. Naming the community in the result lets
+ * someone spot that themselves.
+ *
+ * `user.lastAccessedCommunity` carries only the id, so the name needs a lookup.
+ * It's cached for the lifetime of the process since community names change
+ * rarely and a stale one is cosmetic.
+ */
+
+const { apiRequest } = require('./api');
+
+const nameCache = new Map();
+
+/**
+ * Display name for a community, or null if it can't be resolved. Never throws —
+ * a missing name should degrade the footer, not fail the command.
+ */
+async function getCommunityName(client, communityId) {
+  if (!communityId) return null;
+  if (nameCache.has(communityId)) return nameCache.get(communityId);
+
+  let name = null;
+  try {
+    const res = await apiRequest(client, 'GET', `/api/v1/community/${communityId}`);
+    name = (res && res.community && res.community.name) || null;
+  } catch (err) {
+    if (client && client.error) client.error(`community name ${communityId}: ${err.message}`);
+  }
+
+  nameCache.set(communityId, name);
+  return name;
+}
+
+module.exports = { getCommunityName };

--- a/util/vehicles.js
+++ b/util/vehicles.js
@@ -71,11 +71,20 @@ async function resolveVehicle(client, communityId, value) {
   const raw = String(value || '').trim();
 
   if (OBJECT_ID.test(raw)) {
+    let veh = null;
     try {
-      return await apiRequest(client, 'GET', `/api/v1/vehicle/${raw}`);
+      veh = await apiRequest(client, 'GET', `/api/v1/vehicle/${raw}`);
     } catch (err) {
       return null;
     }
+    // Scope the id path too. The suggestions are already community-scoped, but
+    // Discord still submits whatever was typed if the user ignores the picker,
+    // so a pasted id from another community must not resolve. The plate path
+    // gets this from active_community_id on the search endpoint; fetching by id
+    // has no such filter, so check it here.
+    if (!veh || !veh.vehicle) return null;
+    if (veh.vehicle.activeCommunityID !== communityId) return null;
+    return veh;
   }
 
   const vehicles = await vehiclePlateSearch(client, communityId, raw, 25);

--- a/util/vehicles.js
+++ b/util/vehicles.js
@@ -35,15 +35,27 @@ function vehicleName(v) {
 }
 
 /**
- * Build Discord autocomplete choices (label "PLATE • 2026 Dinka Chavos V6",
- * value = vehicle _id).
+ * Build Discord autocomplete choices, e.g.
+ * "TREEGHJ9 • 2013 Vroom9 Bomber · Green9".
+ *
+ * The label is what the user sees and picks; the value is submitted invisibly
+ * on their behalf. That value is the vehicle's _id rather than the plate
+ * because plates are NOT unique — 167k plate/community pairs have duplicates,
+ * and "NONE" alone appears 1,543 times in a single community. Resolving by
+ * plate would hand back whichever record matched first, which may not be the
+ * one they picked out of the list.
+ *
+ * Colour is included for the same reason: with duplicate plates common, two
+ * rows can otherwise render identically and there is no way to tell them apart.
  */
 async function plateAutocompleteChoices(client, communityId, query) {
   const vehicles = await vehiclePlateSearch(client, communityId, query, 25);
   return vehicles.slice(0, 25).map((v) => {
     const d = v.vehicle || {};
     const name = vehicleName(v);
-    const label = name ? `${d.plate || '—'} • ${name}` : (d.plate || '—');
+    let label = d.plate || '—';
+    if (name) label += ` • ${name}`;
+    if (d.color) label += ` · ${d.color}`;
     return { name: label.slice(0, 100), value: String(v._id) };
   });
 }

--- a/util/vehicles.js
+++ b/util/vehicles.js
@@ -1,0 +1,84 @@
+/**
+ * Shared vehicle lookup helpers for commands that let a user pick a vehicle by
+ * plate (e.g. /search plate). Backed by the same server-side search endpoint
+ * the website's plate autofill uses.
+ *
+ * These go through the API rather than reading Mongo directly — see
+ * util/civilians.js for the same pattern. Beyond consistency, it matters
+ * because API-side fixes do not reach direct-Mongo readers: when the API began
+ * normalizing vehicle flags on read, the API-backed /civilian picked it up and
+ * the direct-Mongo /search plate did not.
+ */
+
+const { apiRequest } = require('./api');
+
+const OBJECT_ID = /^[a-f0-9]{24}$/i;
+
+/**
+ * Server-side plate search, scoped to a community. The endpoint matches the
+ * plate as a case-insensitive substring, which is what makes it usable for
+ * autocomplete. Returns an array of vehicle documents ({ _id, vehicle: {...} }).
+ */
+async function vehiclePlateSearch(client, communityId, query, limit) {
+  const path = `/api/v1/vehicles/search?plate=${encodeURIComponent((query || '').trim())}`
+    + `&active_community_id=${encodeURIComponent(communityId)}&limit=${limit}&page=0`;
+  const res = await apiRequest(client, 'GET', path);
+  if (Array.isArray(res)) return res;
+  return (res && (res.vehicles || res.data)) || [];
+}
+
+/** A short "2026 Dinka Chavos V6" style label, or the type, or nothing. */
+function vehicleName(v) {
+  const d = (v && v.vehicle) || {};
+  const ymm = [d.year, d.make, d.model].filter(Boolean).join(' ');
+  return ymm || d.type || '';
+}
+
+/**
+ * Build Discord autocomplete choices (label "PLATE • 2026 Dinka Chavos V6",
+ * value = vehicle _id).
+ */
+async function plateAutocompleteChoices(client, communityId, query) {
+  const vehicles = await vehiclePlateSearch(client, communityId, query, 25);
+  return vehicles.slice(0, 25).map((v) => {
+    const d = v.vehicle || {};
+    const name = vehicleName(v);
+    const label = name ? `${d.plate || '—'} • ${name}` : (d.plate || '—');
+    return { name: label.slice(0, 100), value: String(v._id) };
+  });
+}
+
+/**
+ * Resolve a vehicle from the value submitted to a plate option. The
+ * autocomplete picker submits the vehicle's _id; a free-typed value falls back
+ * to a plate search, preferring an exact (case-insensitive) plate match so
+ * typing a full plate does not land on some other vehicle that merely contains
+ * it as a substring. Returns the vehicle doc or null.
+ */
+async function resolveVehicle(client, communityId, value) {
+  const raw = String(value || '').trim();
+
+  if (OBJECT_ID.test(raw)) {
+    try {
+      return await apiRequest(client, 'GET', `/api/v1/vehicle/${raw}`);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  const vehicles = await vehiclePlateSearch(client, communityId, raw, 25);
+  if (!vehicles.length) return null;
+
+  const wanted = raw.toLowerCase();
+  const exact = vehicles.find(
+    (v) => String((v.vehicle && v.vehicle.plate) || '').toLowerCase() === wanted
+  );
+  return exact || vehicles[0];
+}
+
+module.exports = {
+  vehiclePlateSearch,
+  plateAutocompleteChoices,
+  resolveVehicle,
+  vehicleName,
+};

--- a/util/vehicles.js
+++ b/util/vehicles.js
@@ -20,11 +20,32 @@ const OBJECT_ID = /^[a-f0-9]{24}$/i;
  * autocomplete. Returns an array of vehicle documents ({ _id, vehicle: {...} }).
  */
 async function vehiclePlateSearch(client, communityId, query, limit) {
-  const path = `/api/v1/vehicles/search?plate=${encodeURIComponent((query || '').trim())}`
-    + `&active_community_id=${encodeURIComponent(communityId)}&limit=${limit}&page=0`;
-  const res = await apiRequest(client, 'GET', path);
+  const res = await plateSearchResponse(client, communityId, query, limit);
   if (Array.isArray(res)) return res;
   return (res && (res.vehicles || res.data)) || [];
+}
+
+/** The raw search response, which also carries `total` for the whole query. */
+async function plateSearchResponse(client, communityId, query, limit) {
+  const path = `/api/v1/vehicles/search?plate=${encodeURIComponent((query || '').trim())}`
+    + `&active_community_id=${encodeURIComponent(communityId)}&limit=${limit}&page=0`;
+  return apiRequest(client, 'GET', path);
+}
+
+/**
+ * How many vehicles the community holds in total. An empty plate matches
+ * everything, so `total` is the community's whole fleet — used to tell someone
+ * whose search found nothing how big the haystack actually was. Returns null if
+ * it can't be determined; this is decoration, not a reason to fail.
+ */
+async function communityVehicleCount(client, communityId) {
+  try {
+    const res = await plateSearchResponse(client, communityId, '', 1);
+    const total = res && res.total;
+    return typeof total === 'number' ? total : null;
+  } catch (err) {
+    return null;
+  }
 }
 
 /** A short "2026 Dinka Chavos V6" style label, or the type, or nothing. */
@@ -99,6 +120,7 @@ async function resolveVehicle(client, communityId, value) {
 
 module.exports = {
   vehiclePlateSearch,
+  communityVehicleCount,
   plateAutocompleteChoices,
   resolveVehicle,
   vehicleName,


### PR DESCRIPTION

<img width="551" height="458" alt="image" src="https://github.com/user-attachments/assets/7b7d355d-60b8-4736-8d11-8f31be88c80d" />

<img width="452" height="441" alt="image" src="https://github.com/user-attachments/assets/4595c513-3963-4607-a031-ab5ed3dca28c" />

<img width="644" height="457" alt="image" src="https://github.com/user-attachments/assets/7e51ca06-fc25-439d-821d-d077489ec997" />



## What prompted this

A real lookup of plate `TREEGHJ9` came back with **no Registration, Insurance or Stolen line at all**:

```
TREEGHJ9
Plate #  TREEGHJ9
Vin #    8XKQBR65YQRNUDVRC
Model    Bomber
Color    Green9
Owner    N/A
```

Every one of those flags had a value (`validRegistration: "false"`, `validInsurance: "true"`, `isStolen: "false"`, `isExempt: "true"`) — the officer just couldn't see any of them. And the vehicle is **exempt** with **invalid registration**, neither surfaced anywhere.

## The underlying problem

`/search plate` read Mongo directly. That's the pattern we're moving away from, and here it had a concrete cost: **API-side fixes never reach it.** When the API began normalizing vehicle flags on read ([police-cad-api#179](https://github.com/Linesmerrill/police-cad-api/pull/179)), the API-backed `/civilian` picked it up and this command did not.

## Changes

**Migrated to the API.** New `util/vehicles.js` mirrors the existing `util/civilians.js` pattern — a search helper, an autocomplete-choices builder, and a resolver. The lookup uses `GET /api/v1/vehicles/search`, the owner uses `GET /api/v1/civilian/{id}`. No direct Mongo left in this path.

**Autocomplete on `plate_number`.** The user types a few characters and picks from a list:

```
typed "TREE" ->
    TREEGHJ9 • 2013 Vroom9 Bomber · Green9
```

Typing a full plate without picking still works, and prefers an exact match over a substring.

> **On the choice value:** Discord autocomplete entries have a display `name` and a submitted `value`. The user only ever sees and types the plate — the value is submitted invisibly when they click a suggestion. That value is the vehicle `_id` rather than the plate because **plates are not unique**: 167,491 plate/community pairs have duplicates, and `NONE` alone appears 1,543 times in one community. Resolving by plate would return whichever record matched first, which may not be the vehicle they picked — the wrong car's owner and stolen status. Colour is in the label for the same reason, so duplicate plates are tellable apart. This is the same mechanism `/search name` already uses.

**Shows what it was dropping.** Plate State, Make, Year and Type; the embed previously had only Model and Color.

**Leads with what an officer is looking for.** An alert line for STOLEN / invalid registration / no insurance / exempt, embed red for stolen and amber for any other flag. Vehicle image as thumbnail when present.

**Registration, Insurance and Stolen render unconditionally.** An omitted Stolen line reads as *unknown* when every other surface would say `No`.

**Failures degrade instead of blanking.** An unreachable owner falls back to `N/A` rather than losing the whole result.

### Same lookup, after

```
TITLE  TREEGHJ9 · 2013 Vroom9 Bomber          (amber)
       ⚠️ Invalid registration
       🛡️ Exempt

Plate #      TREEGHJ9          Plate State  OUT OF STATE
Vin #        8XKQBR65YQRNUDVRC Make         Vroom9
Model        Bomber            Year         2013
Type         Scooter           Color        Green9
Owner        N/A               Registration Invalid
Insurance    Valid             Stolen       No
```

## Verified against the live API

Search by full plate and by partial prefix (the autocomplete path), autocomplete label and value shape, resolution by picked suggestion and by typed plate, exact-match preference, and both not-found paths (unknown plate → `null`, unknown id → `null`, neither throwing).

## Notes

- The two-encoding flag handling stays for now. It's only redundant once the API normalization is deployed everywhere **and** the backfill has run.
- `docs/commands.json` regenerated — the `plate_number` description changed for autocomplete.
- Still on direct Mongo in this file: `/search firearm` and the `users` lookup. Left deliberately, to be migrated when those are next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
