### PR TITLE
feat(gta6): /gta6 launch countdown command

### DIFF
--- a/commands/gta6.js
+++ b/commands/gta6.js
@@ -1,0 +1,118 @@
+const { EmbedBuilder } = require('discord.js');
+const { apiRequest } = require('../util/api');
+
+// Launch countdown, shared with the website and the mobile app. The date comes
+// from the API rather than a constant here so a slipped launch is corrected in
+// one place for every surface.
+//
+// Discord renders <t:UNIX:R> and <t:UNIX:F> in each viewer's own timezone, so
+// the localization the other surfaces have to compute is free here.
+
+// Matches the fallbacks in police-cad/lib/countdown.ts and
+// police-cad-app/utils/countdown.js. Used only if the API is unreachable.
+const FALLBACK = {
+  title: 'Grand Theft Auto VI',
+  subtitle: 'Back to Vice City.',
+  launchDate: '2026-11-19',
+  launchesAt: '2026-11-18T23:00:00Z',
+  mode: 'localMidnight',
+  postLaunchHours: 72,
+};
+
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+// The bot runs on a server, so it cannot know a viewer's timezone. In
+// localMidnight mode it anchors the relative timestamp to the storefront
+// instant and says plainly that the real unlock is local midnight, rather than
+// implying one synchronized worldwide moment.
+function anchorInstant(c) {
+  if (c.launchesAt) {
+    const at = new Date(c.launchesAt);
+    if (!isNaN(at.getTime())) return at;
+  }
+  const m = DATE_ONLY.exec(String(c.launchDate || ''));
+  if (!m) return null;
+  return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], 0, 0, 0));
+}
+
+function daysBetween(fromMs, toMs) {
+  return Math.max(0, Math.ceil((toMs - fromMs) / 86400000));
+}
+
+module.exports = {
+  name: "gta6",
+  description: "See how long until Grand Theft Auto VI launches",
+  permissions: {
+    channel: ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"],
+    member: [],
+  },
+  options: [],
+  SlashCommand: {
+    /**
+     *
+     * @param {require("../structures/LinesPoliceCadBot")} client
+     * @param {import("discord.js").Message} message
+     * @param {string[]} args
+     * @param {*} param3
+     */
+    run: async (client, interaction, args, { GuildDB }) => {
+      if (GuildDB.customChannelStatus == true && !GuildDB.allowedChannels.includes(interaction.channel_id))
+        return interaction.send({ content: `You are not allowed to use the bot in this channel.`, flags: (1 << 6) });
+
+      await interaction.defer({ flags: (1 << 6) });
+
+      let countdown = FALLBACK;
+      try {
+        const list = await apiRequest(client, 'GET', '/api/v1/countdowns?surface=bot');
+        if (Array.isArray(list)) {
+          const found = list.find((c) => c && c.slug === 'gta6' && c.active !== false);
+          if (found) countdown = found;
+        }
+      } catch (err) {
+        // The date is decoration, not a transaction. Fall back rather than
+        // telling someone the countdown is broken.
+        client.error(`gta6 countdown lookup failed, using fallback: ${err.message}`);
+      }
+
+      const anchor = anchorInstant(countdown);
+      if (!anchor) {
+        return interaction.editOriginal({ content: `No launch date is set right now.` });
+      }
+
+      const unix = Math.floor(anchor.getTime() / 1000);
+      const now = Date.now();
+      const postLaunchMs = (countdown.postLaunchHours > 0 ? countdown.postLaunchHours : 72) * 3600000;
+      const launched = now >= anchor.getTime();
+
+      if (launched && now - anchor.getTime() >= postLaunchMs) {
+        return interaction.editOriginal({ content: `${countdown.title} is out. Go play it.` });
+      }
+
+      const embed = new EmbedBuilder()
+        .setColor('#ff2d8e')
+        .setAuthor({ name: 'Countdown', iconURL: client.config.IconURL })
+        .setTitle(countdown.title);
+
+      if (launched) {
+        embed.setDescription(`**Out now.** Launched <t:${unix}:R>.`);
+      } else {
+        const days = daysBetween(now, anchor.getTime());
+        embed
+          .setDescription(countdown.subtitle || null)
+          .addFields(
+            { name: '**Days to go**', value: `\`${days}\``, inline: true },
+            { name: '**Launches**', value: `<t:${unix}:R>`, inline: true },
+            { name: '**Your local time**', value: `<t:${unix}:F>`, inline: false },
+          );
+
+        if (countdown.mode !== 'instant') {
+          embed.setFooter({
+            text: 'Consoles unlock at local midnight, so your exact moment depends on your region.',
+          });
+        }
+      }
+
+      return interaction.editOriginal({ embeds: [embed] });
+    },
+  },
+};

--- a/commands/gta6.js
+++ b/commands/gta6.js
@@ -4,9 +4,6 @@ const { apiRequest } = require('../util/api');
 // Launch countdown, shared with the website and the mobile app. The date comes
 // from the API rather than a constant here so a slipped launch is corrected in
 // one place for every surface.
-//
-// Discord renders <t:UNIX:R> and <t:UNIX:F> in each viewer's own timezone, so
-// the localization the other surfaces have to compute is free here.
 
 // Matches the fallbacks in police-cad/lib/countdown.ts and
 // police-cad-app/utils/countdown.js. Used only if the API is unreachable.
@@ -20,23 +17,35 @@ const FALLBACK = {
 };
 
 const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
 
-// The bot runs on a server, so it cannot know a viewer's timezone. In
-// localMidnight mode it anchors the relative timestamp to the storefront
-// instant and says plainly that the real unlock is local midnight, rather than
-// implying one synchronized worldwide moment.
-function anchorInstant(c) {
+// The website and the app both read the device clock, so they can resolve
+// "midnight local time" exactly. The bot runs on a server and cannot, so it
+// deliberately works at day precision instead of rendering an absolute
+// timestamp that would be wrong for nearly everyone.
+//
+// Midnight UTC on the launch date is the reference point: it is within a day
+// of every viewer's own local midnight, which is all the day count needs.
+function referenceInstant(c) {
+  const m = DATE_ONLY.exec(String(c.launchDate || ''));
+  if (m) return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], 0, 0, 0));
+  // instant mode has no launchDate to work from, and its stored moment is the
+  // real one for everybody.
   if (c.launchesAt) {
     const at = new Date(c.launchesAt);
     if (!isNaN(at.getTime())) return at;
   }
-  const m = DATE_ONLY.exec(String(c.launchDate || ''));
-  if (!m) return null;
-  return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], 0, 0, 0));
+  return null;
 }
 
-function daysBetween(fromMs, toMs) {
-  return Math.max(0, Math.ceil((toMs - fromMs) / 86400000));
+// "November 19, 2026". Date-only, so it reads the same for every viewer.
+function prettyDate(launchDate) {
+  const m = DATE_ONLY.exec(String(launchDate || ''));
+  if (!m) return null;
+  return `${MONTHS[+m[2] - 1]} ${+m[3]}, ${m[1]}`;
 }
 
 module.exports = {
@@ -74,42 +83,48 @@ module.exports = {
         client.error(`gta6 countdown lookup failed, using fallback: ${err.message}`);
       }
 
-      const anchor = anchorInstant(countdown);
-      if (!anchor) {
+      const reference = referenceInstant(countdown);
+      if (!reference) {
         return interaction.editOriginal({ content: `No launch date is set right now.` });
       }
 
-      const unix = Math.floor(anchor.getTime() / 1000);
       const now = Date.now();
       const postLaunchMs = (countdown.postLaunchHours > 0 ? countdown.postLaunchHours : 72) * 3600000;
-      const launched = now >= anchor.getTime();
 
-      if (launched && now - anchor.getTime() >= postLaunchMs) {
-        return interaction.editOriginal({ content: `${countdown.title} is out. Go play it.` });
+      if (now >= reference.getTime()) {
+        if (now - reference.getTime() >= postLaunchMs) {
+          return interaction.editOriginal({ content: `${countdown.title} is out. Go play it.` });
+        }
+        const out = new EmbedBuilder()
+          .setColor('#ff2d8e')
+          .setAuthor({ name: 'Countdown', iconURL: client.config.IconURL })
+          .setTitle(countdown.title)
+          .setDescription('**Out now.**');
+        return interaction.editOriginal({ embeds: [out] });
       }
+
+      const days = Math.max(0, Math.ceil((reference.getTime() - now) / 86400000));
 
       const embed = new EmbedBuilder()
         .setColor('#ff2d8e')
         .setAuthor({ name: 'Countdown', iconURL: client.config.IconURL })
-        .setTitle(countdown.title);
+        .setTitle(countdown.title)
+        .setDescription(countdown.subtitle || null)
+        .addFields({ name: '**Days to go**', value: `\`${days}\``, inline: true });
 
-      if (launched) {
-        embed.setDescription(`**Out now.** Launched <t:${unix}:R>.`);
+      if (countdown.mode === 'instant') {
+        // A synchronized worldwide unlock does have one true moment, and
+        // Discord renders it in each viewer's own timezone. Only correct here.
+        const unix = Math.floor(reference.getTime() / 1000);
+        embed.addFields({ name: '**Launches**', value: `<t:${unix}:F>`, inline: true });
       } else {
-        const days = daysBetween(now, anchor.getTime());
-        embed
-          .setDescription(countdown.subtitle || null)
-          .addFields(
-            { name: '**Days to go**', value: `\`${days}\``, inline: true },
-            { name: '**Launches**', value: `<t:${unix}:R>`, inline: true },
-            { name: '**Your local time**', value: `<t:${unix}:F>`, inline: false },
-          );
-
-        if (countdown.mode !== 'instant') {
-          embed.setFooter({
-            text: 'Consoles unlock at local midnight, so your exact moment depends on your region.',
-          });
-        }
+        // Staggered regional unlock. Naming the date and saying "midnight your
+        // local time" is exactly as precise as the bot can honestly be.
+        embed.addFields({
+          name: '**Launches**',
+          value: `${prettyDate(countdown.launchDate)} at midnight, your local time`,
+          inline: true,
+        });
       }
 
       return interaction.editOriginal({ embeds: [embed] });

--- a/docs/commands.json
+++ b/docs/commands.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": null,
-  "sourceFiles": 26,
+  "sourceFiles": 27,
   "commands": [
     {
       "name": "account",
@@ -295,6 +295,22 @@
       "description": "Disconnect your Discord account from the Lines Police CAD Database",
       "category": "Account",
       "usage": "",
+      "debug": false,
+      "permissions": {
+        "channel": [
+          "VIEW_CHANNEL",
+          "SEND_MESSAGES",
+          "EMBED_LINKS"
+        ],
+        "member": []
+      },
+      "options": []
+    },
+    {
+      "name": "gta6",
+      "description": "See how long until Grand Theft Auto VI launches",
+      "category": "Other",
+      "usage": null,
       "debug": false,
       "permissions": {
         "channel": [


### PR DESCRIPTION
The Discord half of the GTA 6 countdown. Pairs with Linesmerrill/police-cad-api#187 (merged, endpoint live) and Linesmerrill/police-cad#973 (the web strip); the mobile card is already on `production`.

## What it does

`/gta6` replies with an embed showing the days remaining and the launch date:

```
Countdown
Grand Theft Auto VI
Back to Vice City.

Days to go     Launches
83             November 19, 2026 at midnight, your local time
```

Ephemeral, matching the other read commands.

## Day precision is deliberate

The website and the app read the device clock, so they resolve "midnight local time" exactly and show a real time. **The bot runs on a server and cannot**, so it works at the precision it actually has.

The first version of this got it wrong and it is worth recording why. It rendered `<t:launchesAt:F>` as "Your local time", reaching for Discord timestamps because they localize per viewer for free. But they localize a *fixed moment*, and `localMidnight` mode premise is that there is not one. The storefront instant (23:00 UTC Nov 18) came out as "November 18, 2026 at 4:00 PM" in MST — wrong time, wrong day, and flatly contradicting the footer right below it about local midnight. Caught in live testing.

Naming the date and saying "midnight, your local time" is exactly as precise as the bot can honestly be, and it agrees with what the other two surfaces display.

The day count anchors to midnight UTC on `launchDate`, which sits within a day of every viewer own local midnight rather than drifting for people far from UTC.

`instant` mode still renders `<t:...:F>`. There a single worldwide moment genuinely exists, so the absolute timestamp is correct — flip the mode and the bot switches to the precise rendering on its own.

## Notes

- Reads through `util/api.js` rather than querying Mongo directly, per the ongoing migration. The date has exactly one home.
- Falls back to a baked-in date if the API is unreachable. This is decoration, not a transaction; being a day stale beats telling someone the countdown is broken.
- Retires itself once the launch is past `postLaunchHours`.
- No `verifyUseCommand` role gate, unlike `check-status` and friends. It exposes no community data, so gating a public hype countdown behind the CAD role allowlist seemed wrong. Easy to add if you disagree.
- `docs/commands.json` regenerated in the first commit; the name, description and options did not change in the fix, so it is still current.

## Verification

Ran live against the alpha bot in 3 guilds, reading the seeded production record through the deployed API. Confirmed the embed contents, the ephemeral flag, and the corrected copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)